### PR TITLE
feat(stubs): Stub Manager

### DIFF
--- a/micropy/exceptions.py
+++ b/micropy/exceptions.py
@@ -6,7 +6,7 @@
 class StubError(Exception):
     """Exception for any errors raised by stubs"""
 
-    def __init__(self, stub, message=None):
+    def __init__(self, stub=None, message=None):
         self.stub = stub
         self.message = message
         if message is None:
@@ -16,11 +16,11 @@ class StubError(Exception):
 class StubValidationError(StubError):
     """Raised when a stub fails validation"""
 
-    def __init__(self, stub, errors):
+    def __init__(self, path, errors, *args, **kwargs):
         errs = '\n'.join(errors)
-        msg = f"Stub at [{stub.path}] encountered \
+        msg = f"Stub at [{str(path)}] encountered \
             the following validation errors: {errs}"
-        super().__init__(stub, message=msg)
+        super().__init__(message=msg, *args, **kwargs)
 
     def __str__(self):
         return self.message

--- a/micropy/logger.py
+++ b/micropy/logger.py
@@ -19,12 +19,14 @@ class Log:
         self.parent_logger = ServiceLog()
         self.loggers = [self.parent_logger]
 
-    def add_logger(self, service_name, base_color="white", **kwargs):
+    @classmethod
+    def add_logger(cls, service_name, base_color="white", **kwargs):
         """Creates a new child ServiceLog instance"""
-        parent = kwargs.get("parent", self.parent_logger)
+        _self = cls()
+        parent = kwargs.get("parent", _self.parent_logger)
         logger = ServiceLog(service_name, base_color,
                             parent=parent)
-        self.loggers.append(logger)
+        _self.loggers.append(logger)
         return logger
 
     def get_logger(self, service_name):

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from rshell import main as rsh
 
-from micropy.stubs import Stub
+from micropy.stubs import StubManager
 from micropy.logger import Log
 from micropy.exceptions import StubValidationError
 
@@ -18,7 +18,7 @@ class MicroPy:
     STUBBER = LIB / 'stubber'
     FILES = Path.home() / '.micropy'
     STUB_DIR = FILES / 'stubs'
-    STUBS = []
+    STUBS = StubManager()
 
     def __init__(self):
         self.log = Log().get_logger('MicroPy')
@@ -28,8 +28,6 @@ class MicroPy:
         """creates necessary directories for micropy"""
         self.log.debug("\n---- MicropyCLI Session ----")
         self.log.debug("Loading stubs...")
-        MicroPy.STUBS = [Stub(i) for i in self.STUB_DIR.iterdir()
-                         ] if self.STUB_DIR.exists() else []
         [self.log.debug(f"Loaded: {stub}") for stub in self.STUBS]
         if not self.STUB_DIR.exists():
             self.log.debug("Running first time setup...")
@@ -39,10 +37,8 @@ class MicroPy:
             initial_stubs_dir = self.STUBBER / 'stubs'
             self.log.debug("Adding stubs from Josverl/micropython-stubber")
             with self.log.silent():
-                for stub in initial_stubs_dir.iterdir():
-                    self.add_stub(stub)
-            return True
-        return False
+                self.STUBS.add_from(initial_stubs_dir, self.STUB_DIR)
+        self.STUBS.load_from(self.STUB_DIR)
 
     def add_stub(self, path):
         """Adds stub to micropy folder

--- a/micropy/project/template.py
+++ b/micropy/project/template.py
@@ -96,7 +96,7 @@ class TemplateProvider:
     TEMPLATE_DIR = Path(__file__).parent / 'template'
 
     def __init__(self, log=None):
-        self.log = log or Log().add_logger('Templater')
+        self.log = log or Log.add_logger('Templater')
         if self.__class__.ENVIRONMENT is None:
             loader = FileSystemLoader(str(self.TEMPLATE_DIR))
             self.__class__.ENVIRONMENT = Environment(loader=loader)

--- a/micropy/stubs/__init__.py
+++ b/micropy/stubs/__init__.py
@@ -2,6 +2,6 @@
 
 """Module for stub handling."""
 
-from .stubs import Stub
+from .stubs import Stub, StubManager
 
-__all__ = ['Stub']
+__all__ = ['Stub', 'StubManager']

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -29,6 +29,8 @@ class StubManager:
         self._loaded = set()
         self.resource = resource
         self.log = Log.add_logger('Stubs', 'yellow')
+        if self.resource:
+            self.load_from(resource)
 
     def __iter__(self):
         return iter(self._loaded)

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -10,6 +10,49 @@ from micropy.utils import Validator
 from micropy.exceptions import StubValidationError
 
 
+class StubManager:
+    """Manager for Stub Instances"""
+    _schema = Path(__file__).parent / 'schema.json'
+    _loaded = []
+
+    def __init__(self):
+        self.log = Log.add_logger('Stubs', 'yellow')
+
+    def __iter__(self):
+        return iter(self._loaded)
+
+    def _load(self, path):
+        """Loads a stub"""
+        try:
+            self.validate(path)
+        except StubValidationError:
+            pass
+        else:
+            stub = Stub(path)
+            self.loaded.append(stub)
+            return stub
+
+    def validate(self, path):
+        """Validates stubs"""
+        self.log.debug(f"Validating: {path}")
+        stub_info = path / 'modules.json'
+        val = Validator(self._schema)
+        try:
+            val.validate(stub_info)
+        except FileNotFoundError:
+            raise StubValidationError(
+                path, [f"{path.name} contains no modules.json file!"])
+        except Exception as e:
+            raise StubValidationError(path, str(e))
+
+    def load_from(self, directory):
+        """Load all stubs in a directory"""
+        dir_path = Path(str(directory)).resolve()
+        dirs = dir_path.iterdir()
+        stubs = [self._load(d) for d in dirs]
+        return stubs
+
+
 class Stub:
     """Handles Stub Files
 
@@ -17,12 +60,10 @@ class Stub:
     :param Optional[str] copy_to: directory to copy stub to if it validates
 
     """
-    SCHEMA = Path(__file__).parent / 'schema.json'
 
     def __init__(self, path, copy_to=None, **kwargs):
         self.path = path.absolute()
         self.log = Log.add_logger('Stubs', 'yellow')
-        self.validate(path)
         module = self.path / 'modules.json'
         info = json.load(module.open())
         device = info.pop(0)
@@ -36,19 +77,6 @@ class Stub:
         self.version = device.get('version')
         if copy_to is not None:
             self.copy_to(copy_to)
-
-    def validate(self, path):
-        """Validates stubs"""
-        self.log.debug(f"Validating: {path}")
-        stub_info = path / 'modules.json'
-        val = Validator(self.SCHEMA)
-        try:
-            val.validate(stub_info)
-        except FileNotFoundError:
-            raise StubValidationError(
-                self, [f"{path.name} contains no modules.json file!"])
-        except Exception as e:
-            raise StubValidationError(self, str(e))
 
     def copy_to(self, dest):
         """Copy stub to a directory"""

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -13,9 +13,9 @@ from micropy.exceptions import StubValidationError
 class StubManager:
     """Manager for Stub Instances"""
     _schema = Path(__file__).parent / 'schema.json'
-    _loaded = set()
 
     def __init__(self):
+        self._loaded = set()
         self.log = Log.add_logger('Stubs', 'yellow')
 
     def __iter__(self):

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -11,11 +11,23 @@ from micropy.exceptions import StubValidationError
 
 
 class StubManager:
-    """Manager for Stub Instances"""
+    """Manages a collection of Stubs
+
+    Kwargs:
+        resource (str): Default resource path
+
+    Raises:
+        StubValidationError: a stub is missing a def file
+        StubValidationError: a stubs def file is not valid
+
+    Returns:
+        object: Instance of StubManager
+    """
     _schema = Path(__file__).parent / 'schema.json'
 
-    def __init__(self):
+    def __init__(self, resource=None):
         self._loaded = set()
+        self.resource = resource
         self.log = Log.add_logger('Stubs', 'yellow')
 
     def __iter__(self):

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -60,6 +60,22 @@ class StubManager:
         except Exception as e:
             raise StubValidationError(path, str(e))
 
+    def is_valid(self, path):
+        """Check if stub is valid without raising an exception
+
+        Args:
+            path (str): path to stub
+
+        Returns:
+            bool: True if stub is valid
+        """
+        try:
+            self.validate(path)
+        except StubValidationError:
+            return False
+        else:
+            return True
+
     def load_from(self, directory, *args, **kwargs):
         """Load all stubs in a directory"""
         dir_path = Path(str(directory)).resolve()
@@ -72,11 +88,25 @@ class StubManager:
         dest_path = Path(str(dest_dir)).resolve()
         return self.load_from(source_dir, copy_to=dest_dir)
 
-    def add(self, source_dir, dest_dir):
-        """add single stub"""
-        source_path = Path(str(source_dir)).resolve()
-        dest_path = Path(str(dest_dir)).resolve()
-        return self._load(source_dir, copy_to=dest_dir)
+    def add(self, source, dest=None):
+        """Add stub(s) from source
+
+        Args:
+            source (str): path to stub(s)
+            dest (str, optional): path to copy stubs to.
+                Defaults to self.resource
+
+        Raises:
+            TypeError: No resource or destination provided
+        """
+        source_path = Path(str(source)).resolve()
+        _dest = dest or self.resource
+        if not _dest:
+            raise TypeError("No Stub Destination Provided!")
+        dest = Path(str(_dest)).resolve()
+        if not self.is_valid(source_path):
+            return self.load_from(source_path, copy_to=dest)
+        return self._load(source_path, copy_to=dest)
 
 
 class Stub:

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -89,6 +89,7 @@ class Stub:
         self.release = device.get('release')
         self.sysname = device.get('sysname')
         self.version = device.get('version')
+        self.name = f"{self.sysname}@{self.version}"
         if copy_to is not None:
             self.copy_to(copy_to)
 
@@ -101,13 +102,13 @@ class Stub:
         return self
 
     def __eq__(self, other):
-        return repr(self) == repr(other)
+        return self.name == other.name
 
     def __hash__(self):
-        return hash(repr(self))
+        return hash(self.name)
 
     def __repr__(self):
         return f"Stub(machine={self.machine}, nodename={self.nodename}, release={self.release}, sysname={self.sysname}, version={self.version})"
 
     def __str__(self):
-        return f"{self.sysname}@{self.version}"
+        return self.name

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -21,7 +21,7 @@ class Stub:
 
     def __init__(self, path, copy_to=None, **kwargs):
         self.path = path.absolute()
-        self.log = Log().add_logger('Stubs', 'yellow')
+        self.log = Log.add_logger('Stubs', 'yellow')
         self.validate(path)
         module = self.path / 'modules.json'
         info = json.load(module.open())

--- a/tests/data/esp8266_invalid_stub/modules.json
+++ b/tests/data/esp8266_invalid_stub/modules.json
@@ -1,0 +1,10 @@
+[
+    {
+        "nodename": "esp32",
+        "release": "1.10.0"
+    },
+    {
+        "pathtofile": "/foobar/foo/bar.py",
+        "something": "bar"
+    }
+]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,9 @@ def test_initial_stubs(mock_micropy_path):
 def test_add_stub(mock_micropy, shared_datadir):
     """Test Adding Valid Stub"""
     stub_path = shared_datadir / 'esp8266_test_stub'
-    stub = mock_micropy.add_stub(stub_path)
+    stubs = mock_micropy.STUBS
+    # stub = mock_micropy.add_stub(stub_path)
+    stub = stubs.add(stub_path)
     assert stub in mock_micropy.STUBS
     assert stub.path in mock_micropy.STUB_DIR.iterdir()
     assert stub.path.exists()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,7 +23,7 @@ def test_initial_stubs(mock_micropy_path):
     for stub in mp.STUBS:
         stub_dirs = stub_dir.iterdir()
         assert stub.path.exists()
-        assert stub.path in stub_dirs
+        assert stub.path.name in [p.name for p in stub_dirs]
     assert len(mp.STUBS) == len(list(stub_dir.iterdir()))
 
 
@@ -31,8 +31,7 @@ def test_add_stub(mock_micropy, shared_datadir):
     """Test Adding Valid Stub"""
     stub_path = shared_datadir / 'esp8266_test_stub'
     stubs = mock_micropy.STUBS
-    # stub = mock_micropy.add_stub(stub_path)
-    stub = stubs.add(stub_path)
-    assert stub in mock_micropy.STUBS
+    stub = stubs.add(stub_path, mock_micropy.STUB_DIR)
+    assert stub in list(mock_micropy.STUBS)
     assert stub.path in mock_micropy.STUB_DIR.iterdir()
     assert stub.path.exists()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,7 +6,7 @@ from micropy.project.template import TemplateProvider
 
 def test_project_init(mock_micropy, mock_cwd):
     """Test project setup"""
-    proj_stubs = mock_micropy.STUBS[:2]
+    proj_stubs = list(mock_micropy.STUBS)[:2]
     proj = Project("ProjName", proj_stubs)
     assert proj.path == mock_cwd / 'ProjName'
     assert proj.name == 'ProjName'
@@ -14,7 +14,7 @@ def test_project_init(mock_micropy, mock_cwd):
 
 def test_project_structure(mock_micropy, mock_cwd):
     """Test if project creates files"""
-    proj_stubs = mock_micropy.STUBS[:2]
+    proj_stubs = list(mock_micropy.STUBS)[:2]
     proj = Project("ProjName", proj_stubs)
     proj.create()
     templ_files = sorted([i.name for i in (

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -28,7 +28,7 @@ def test_bad_stub(tmp_path):
 def test_valid_stub(shared_datadir):
     """should have all attributes"""
     stub_path = shared_datadir / 'esp8266_test_stub'
-    stub = stubs.Stub(stub_path)
+    stub = stubs.stubs.Stub(stub_path)
     expect_module = {
         "file": "/stubs/esp8266_test_stub/micropython.py",
         "module": "micropython"
@@ -39,5 +39,40 @@ def test_valid_stub(shared_datadir):
     assert stub.version == "v1.9.4-8-ga9a3caad0 on 2018-05-11"
     assert stub.machine == "ESP module with ESP8266"
     assert stub.sysname == "esp8266"
+    assert stub.name == "esp8266@v1.9.4-8-ga9a3caad0 on 2018-05-11"
     assert expect_module in stub.modules
     assert str(stub) == "esp8266@v1.9.4-8-ga9a3caad0 on 2018-05-11"
+
+
+def test_add_single_stub(shared_datadir, tmp_path):
+    """should add a single stub"""
+    stub_path = shared_datadir / 'esp8266_test_stub'
+    manager = stubs.StubManager()
+    manager.add(stub_path, dest=tmp_path)
+    assert len(manager) == 1
+    assert stub_path.name in [d.name for d in tmp_path.iterdir()]
+
+
+def test_add_stubs_from_dir(datadir, tmp_path):
+    """should add all valid stubs in directory"""
+    manager = stubs.StubManager()
+    manager.add(datadir, dest=tmp_path)
+    assert len(manager) == 2
+    assert len(list(tmp_path.iterdir())) - 1 == len(manager)
+
+
+def test_add_with_resource(datadir, tmp_path):
+    """should not require dest kwarg"""
+    manager = stubs.StubManager(resource=tmp_path)
+    manager.add(datadir)
+    assert len(manager) == 2
+    # Subtract 1 cause tmp_path has datadir in it for some unrelated reason
+    # as in, before adding stubs
+    assert len(list(tmp_path.iterdir())) - 1 == len(manager)
+
+
+def test_add_no_resource_no_dest(datadir):
+    """should fail with typeerror"""
+    manager = stubs.StubManager()
+    with pytest.raises(TypeError):
+        manager.add(datadir)

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -4,6 +4,14 @@ import pytest
 from micropy import stubs, exceptions
 
 
+def test_stubs_load(mock_micropy):
+    """should load stubs"""
+    path = mock_micropy.STUBS_DIR
+    manager = stubs.Stubs()
+    manager.load_from(path)
+    assert len(path.iterdir()) == len(manager.loaded)
+
+
 def test_bad_stub(tmp_path):
     """should raise exception on invalid stub"""
     with pytest.raises(exceptions.StubValidationError):

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -4,14 +4,6 @@ import pytest
 from micropy import stubs, exceptions
 
 
-def test_stubs_load(mock_micropy):
-    """should load stubs"""
-    path = mock_micropy.STUBS_DIR
-    manager = stubs.StubManager()
-    manager.load_from(path)
-    assert len(path.iterdir()) == len(manager.loaded)
-
-
 def test_stub_validation(shared_datadir):
     """should pass validation"""
     stub_path = shared_datadir / 'esp8266_test_stub'

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -76,3 +76,9 @@ def test_add_no_resource_no_dest(datadir):
     manager = stubs.StubManager()
     with pytest.raises(TypeError):
         manager.add(datadir)
+
+
+def test_loads_from_resource(datadir):
+    """should load from resource if provided"""
+    manager = stubs.StubManager(resource=datadir)
+    assert len(manager) == len(list(datadir.iterdir())) - 1

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -21,7 +21,7 @@ def test_stub_validation(shared_datadir):
 
 def test_bad_stub_validation(shared_datadir):
     """should fail validation"""
-    stub_path = shared_datadir / 'esp'
+    stub_path = shared_datadir / 'esp8266_invalid_stub'
     manager = stubs.StubManager()
     with pytest.raises(exceptions.StubValidationError):
         manager.validate(stub_path)
@@ -29,7 +29,7 @@ def test_bad_stub_validation(shared_datadir):
 
 def test_bad_stub(tmp_path):
     """should raise exception on invalid stub"""
-    with pytest.raises(exceptions.StubValidationError):
+    with pytest.raises(FileNotFoundError):
         stubs.Stub(tmp_path)
 
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -7,9 +7,24 @@ from micropy import stubs, exceptions
 def test_stubs_load(mock_micropy):
     """should load stubs"""
     path = mock_micropy.STUBS_DIR
-    manager = stubs.Stubs()
+    manager = stubs.StubManager()
     manager.load_from(path)
     assert len(path.iterdir()) == len(manager.loaded)
+
+
+def test_stub_validation(shared_datadir):
+    """should pass validation"""
+    stub_path = shared_datadir / 'esp8266_test_stub'
+    manager = stubs.StubManager()
+    manager.validate(stub_path)
+
+
+def test_bad_stub_validation(shared_datadir):
+    """should fail validation"""
+    stub_path = shared_datadir / 'esp'
+    manager = stubs.StubManager()
+    with pytest.raises(exceptions.StubValidationError):
+        manager.validate(stub_path)
 
 
 def test_bad_stub(tmp_path):
@@ -19,7 +34,7 @@ def test_bad_stub(tmp_path):
 
 
 def test_valid_stub(shared_datadir):
-    """should not raise any validation errors"""
+    """should have all attributes"""
     stub_path = shared_datadir / 'esp8266_test_stub'
     stub = stubs.Stub(stub_path)
     expect_module = {

--- a/tests/test_stubs/bad_test_stub/modules.json
+++ b/tests/test_stubs/bad_test_stub/modules.json
@@ -1,0 +1,10 @@
+[
+    {
+        "nodename": "esp32",
+        "release": "1.10.0"
+    },
+    {
+        "pathtofile": "/foobar/foo/bar.py",
+        "something": "bar"
+    }
+]

--- a/tests/test_stubs/esp32_test_stub/modules.json
+++ b/tests/test_stubs/esp32_test_stub/modules.json
@@ -1,0 +1,17 @@
+[
+    {
+        "nodename": "esp32",
+        "release": "2.2.0-dev(9422289)",
+        "version": "v1.9.4-8-ga9a3caad0 on 2018-05-11",
+        "machine": "ESP module with ESP32",
+        "sysname": "esp32"
+    },
+    { "stubber": "1.1.2" },
+    { "file": "/stubs/esp8266_test_stub/math.py", "module": "math" },
+    {
+        "file": "/stubs/esp8266_test_stub/micropython.py",
+        "module": "micropython"
+    },
+    { "file": "/stubs/esp8266_test_stub/sys.py", "module": "sys" },
+    { "file": "/stubs/esp8266_test_stub/time.py", "module": "time" }
+]

--- a/tests/test_stubs/esp8266_test_stub/modules.json
+++ b/tests/test_stubs/esp8266_test_stub/modules.json
@@ -1,0 +1,17 @@
+[
+    {
+        "nodename": "esp8266",
+        "release": "2.2.0-dev(9422289)",
+        "version": "v1.9.4-8-ga9a3caad0 on 2018-05-11",
+        "machine": "ESP module with ESP8266",
+        "sysname": "esp8266"
+    },
+    { "stubber": "1.1.2" },
+    { "file": "/stubs/esp8266_test_stub/math.py", "module": "math" },
+    {
+        "file": "/stubs/esp8266_test_stub/micropython.py",
+        "module": "micropython"
+    },
+    { "file": "/stubs/esp8266_test_stub/sys.py", "module": "sys" },
+    { "file": "/stubs/esp8266_test_stub/time.py", "module": "time" }
+]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -6,7 +6,7 @@ import pylint.lint
 
 
 def test_vscode_template(mock_micropy, tmp_path):
-    stubs = mock_micropy.STUBS[:3]
+    stubs = list(mock_micropy.STUBS)[:3]
     prov = TemplateProvider()
     prov.render_to('vscode', tmp_path, stubs=stubs)
     expected_path = tmp_path / '.vscode' / 'settings.json'
@@ -25,7 +25,7 @@ def test_vscode_template(mock_micropy, tmp_path):
 
 
 def test_pylint_template(mock_micropy, tmp_path):
-    stubs = mock_micropy.STUBS[:3]
+    stubs = list(mock_micropy.STUBS)[:3]
     prov = TemplateProvider()
     prov.render_to("pylint", tmp_path, stubs=stubs)
     expected_path = tmp_path / '.pylintrc'


### PR DESCRIPTION
Move stub-related functionality away from `MicroPy` class to its own dedicated `StubManager` class that will handle all instances of `Stub`

Will open up for "remote" stubs later on, which can be downloaded and will be sourced from `micropy-stubs`

Closes #6 