### PR TITLE
Stub Management, Logic Separation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "micropy/lib/stubber"]
 	path = micropy/lib/stubber
 	url = https://github.com/Josverl/micropython-stubber.git
+	branch = stub/esp8622

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -5,9 +5,11 @@
 import click
 import questionary as prompt
 from questionary import Choice
+from pathlib import Path
 
 from micropy.main import MicroPy
 from micropy.project import Project
+from micropy.exceptions import StubError
 
 mp = MicroPy()
 
@@ -41,19 +43,35 @@ def init(project_name=""):
     exists=True, file_okay=False, resolve_path=True))
 def add(path):
     """Add stubs"""
-    return mp.add_stub(path)
+    stub_path = Path(str(path))
+    try:
+        mp.log.info(f"Adding stub from $[{stub_path}]")
+        mp.STUBS.validate(stub_path)
+        stub = mp.STUBS.add(stub_path)
+    except StubError:
+        mp.log.error(f"{stub_path.name} is not a valid stub!")
+    else:
+        mp.log.success(f"{stub.name} added!")
 
 
 @stubs.command()
 def list():
-    """Lists all stubs"""
-    return mp.list_stubs()
+    """Lists available stubs"""
+    mp.log.info("$w[Available Stubs:]")
+    for stub in mp.STUBS:
+        mp.log.info(str(stub))
+    return mp.log.info(f"$[Total:] {len(mp.STUBS)}")
 
 
 @stubs.command()
 @click.argument('port', required=True)
 def create(port):
-    """Create stubs from a pyboard"""
+    """Create stubs from a pyboard
+
+    MicropyCli uses Josverl's micropython-stubber for stub creation.
+    For more info,
+    checkout his git repo @ https://github.com/Josverl/micropython-stubber
+    """
     return mp.create_stubs(port)
 
 

--- a/micropy/exceptions.py
+++ b/micropy/exceptions.py
@@ -6,7 +6,7 @@
 class StubError(Exception):
     """Exception for any errors raised by stubs"""
 
-    def __init__(self, stub, message=None):
+    def __init__(self, stub=None, message=None):
         self.stub = stub
         self.message = message
         if message is None:
@@ -16,11 +16,11 @@ class StubError(Exception):
 class StubValidationError(StubError):
     """Raised when a stub fails validation"""
 
-    def __init__(self, stub, errors):
+    def __init__(self, path, errors, *args, **kwargs):
         errs = '\n'.join(errors)
-        msg = f"Stub at [{stub.path}] encountered \
+        msg = f"Stub at [{str(path)}] encountered \
             the following validation errors: {errs}"
-        super().__init__(stub, message=msg)
+        super().__init__(message=msg, *args, **kwargs)
 
     def __str__(self):
         return self.message

--- a/micropy/exceptions.py
+++ b/micropy/exceptions.py
@@ -18,8 +18,8 @@ class StubValidationError(StubError):
 
     def __init__(self, path, errors, *args, **kwargs):
         errs = '\n'.join(errors)
-        msg = f"Stub at [{str(path)}] encountered \
-            the following validation errors: {errs}"
+        msg = (f"Stub at[{str(path)}] encountered"
+               f" the following validation errors: {errs}")
         super().__init__(message=msg, *args, **kwargs)
 
     def __str__(self):

--- a/micropy/logger.py
+++ b/micropy/logger.py
@@ -19,12 +19,14 @@ class Log:
         self.parent_logger = ServiceLog()
         self.loggers = [self.parent_logger]
 
-    def add_logger(self, service_name, base_color="white", **kwargs):
+    @classmethod
+    def add_logger(cls, service_name, base_color="white", **kwargs):
         """Creates a new child ServiceLog instance"""
-        parent = kwargs.get("parent", self.parent_logger)
+        _self = cls()
+        parent = kwargs.get("parent", _self.parent_logger)
         logger = ServiceLog(service_name, base_color,
                             parent=parent)
-        self.loggers.append(logger)
+        _self.loggers.append(logger)
         return logger
 
     def get_logger(self, service_name):

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -5,12 +5,9 @@
 import tempfile
 from pathlib import Path
 
-from rshell import main as rsh
-
 from micropy.stubs import StubManager
-from micropy.exceptions import StubValidationError
 from micropy.logger import Log
-from micropy.stubs import Stub
+from micropy.utils import PyboardWrapper
 
 
 class MicroPy:
@@ -19,7 +16,7 @@ class MicroPy:
     STUBBER = LIB / 'stubber'
     FILES = Path.home() / '.micropy'
     STUB_DIR = FILES / 'stubs'
-    STUBS = StubManager()
+    STUBS = None
 
     def __init__(self):
         self.log = Log().get_logger('MicroPy')
@@ -29,78 +26,53 @@ class MicroPy:
         """creates necessary directories for micropy"""
         self.log.debug("\n---- MicropyCLI Session ----")
         self.log.debug("Loading stubs...")
-        [self.log.debug(f"Loaded: {stub}") for stub in self.STUBS]
-        if not self.STUB_DIR.exists():
-            self.log.debug("Running first time setup...")
-            self.log.debug(f"Creating .micropy directory @ {self.FILES}")
-            self.FILES.mkdir(exist_ok=True)
-            self.STUB_DIR.mkdir()
-            initial_stubs_dir = self.STUBBER / 'stubs'
-            self.log.debug("Adding stubs from Josverl/micropython-stubber")
-            with self.log.silent():
-                self.STUBS.add_from(initial_stubs_dir, self.STUB_DIR)
-        self.STUBS.load_from(self.STUB_DIR)
-
-    def add_stub(self, path):
-        """Adds stub to micropy folder
-
-        :param str path: path of stub to add
-
-        """
-        stub_path = Path(path)
-        self.log.info(f"Adding $[{stub_path.name}] to stubs...")
-        stub_out = self.STUB_DIR / stub_path.name
-        try:
-            stub = Stub(path, copy_to=stub_out)
-        except StubValidationError:
-            self.log.error(f"{stub_path.name} is not a valid stub!")
-        else:
-            self.STUBS.append(stub)
-            self.log.debug(f"Added New Stub: {stub}")
-            self.log.success("Done!")
-            return stub
+        if self.STUB_DIR.exists():
+            self.STUBS = StubManager(resource=self.STUB_DIR)
+            return self.STUBS
+        self.log.debug("Running first time setup...")
+        self.log.debug(f"Creating .micropy directory @ {self.FILES}")
+        self.FILES.mkdir(exist_ok=True)
+        self.STUB_DIR.mkdir()
+        initial_stubs_dir = self.STUBBER / 'stubs'
+        self.log.debug("Adding stubs from Josverl/micropython-stubber")
+        with self.log.silent():
+            self.STUBS = StubManager(resource=self.STUB_DIR)
+            self.STUBS.add(initial_stubs_dir)
+            return self.STUBS
 
     def create_stubs(self, port):
-        """Create stubs from a pyboard
+        """Create and add stubs from Pyboard
 
-        :param str port: port of pyboard
+        Args:
+            port (str): Port of Pyboard
 
+        Returns:
+            Stub: generated stub
         """
-        create_script = self.STUBBER / 'createstubs.py'
-        stubber_logger = self.STUBBER / 'lib' / 'logging.py'
-        self.log.info(f"Connecting to PyBoard @ $[{port}]...")
-        rsh.ASCII_XFER = False
-        rsh.connect(port)
+        # TODO: Probably move this functionality to cli module
+        self.log.info(f"Connecting to Pyboard @ $[{port}]...")
+        try:
+            pyb = PyboardWrapper(port)
+        except SystemExit:
+            self.log.error(
+                f"Failed to connect, are you sure $[{port}] is correct?")
+            return None
         self.log.success("Connected!")
-        dev = rsh.DEVS[0]
-        self.log.info("Uploading $[createstubs.py]...")
-        rsh.cp(str(create_script.absolute()),
-               f"{dev.name_path}/{create_script.name}")
-        rsh.cp(str(stubber_logger.absolute()),
-               f"{dev.name_path}/{stubber_logger.name}")
+        # TODO: determine which script to use based on device
+        script_path = self.STUBBER / 'minified.py'
+        self.log.info("Executing stubber on pyboard...")
+        try:
+            pyb.run(script_path)
+        except Exception as e:
+            # TODO: Handle more usage cases
+            self.log.error(f"Failed to execute script: {str(e)}")
+            return None
         self.log.success("Done!")
-        self.log.info("Executing $[createstubs.py]")
-        pyb = dev.pyb
-        pyb.enter_raw_repl()
-        pyb.exec("import createstubs")
-        pyb.exit_raw_repl()
-        self.log.success("Done!")
-        self.log.info("Downloading Stubs...")
-        stub_name = rsh.auto(
-            rsh.listdir_stat, f'{dev.name_path}/stubs',
-            show_hidden=False)[0][0]
+        self.log.info("Copying stubs...")
         with tempfile.TemporaryDirectory() as tmpdir:
-            rsh.rsync(
-                f"{dev.name_path}/stubs", tmpdir, recursed=True, mirror=False,
-                dry_run=False, print_func=lambda * args: None,
-                sync_hidden=False)
-            stub_path = Path(tmpdir) / stub_name
-            self.add_stub(stub_path)
-        self.log.success("Done!")
-        return self.list_stubs()
-
-    def list_stubs(self):
-        """Lists all available stubs"""
-        self.log.info("$w[Available Stubs:]")
-        [self.log.info(str(i)) for i in self.STUBS]
-        self.log.info(f"$[Total Stubs:] {len(self.STUBS)}")
+            out_dir = pyb.copy_dir("/stubs", tmpdir)
+            stub_path = next(out_dir.iterdir())
+            self.log.info(f"Copied Stubs: $[{stub_path.name}]")
+            stub = self.STUBS.add(stub_path)
+        self.log.success(f"Added {stub.name} to stubs!")
+        return stub

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from rshell import main as rsh
 
+from micropy.stubs import StubManager
 from micropy.exceptions import StubValidationError
 from micropy.logger import Log
 from micropy.stubs import Stub
@@ -18,7 +19,7 @@ class MicroPy:
     STUBBER = LIB / 'stubber'
     FILES = Path.home() / '.micropy'
     STUB_DIR = FILES / 'stubs'
-    STUBS = []
+    STUBS = StubManager()
 
     def __init__(self):
         self.log = Log().get_logger('MicroPy')
@@ -28,8 +29,6 @@ class MicroPy:
         """creates necessary directories for micropy"""
         self.log.debug("\n---- MicropyCLI Session ----")
         self.log.debug("Loading stubs...")
-        MicroPy.STUBS = [Stub(i) for i in self.STUB_DIR.iterdir()
-                         ] if self.STUB_DIR.exists() else []
         [self.log.debug(f"Loaded: {stub}") for stub in self.STUBS]
         if not self.STUB_DIR.exists():
             self.log.debug("Running first time setup...")
@@ -39,10 +38,8 @@ class MicroPy:
             initial_stubs_dir = self.STUBBER / 'stubs'
             self.log.debug("Adding stubs from Josverl/micropython-stubber")
             with self.log.silent():
-                for stub in initial_stubs_dir.iterdir():
-                    self.add_stub(stub)
-            return True
-        return False
+                self.STUBS.add_from(initial_stubs_dir, self.STUB_DIR)
+        self.STUBS.load_from(self.STUB_DIR)
 
     def add_stub(self, path):
         """Adds stub to micropy folder

--- a/micropy/project/template.py
+++ b/micropy/project/template.py
@@ -97,7 +97,7 @@ class TemplateProvider:
     TEMPLATE_DIR = Path(__file__).parent / 'template'
 
     def __init__(self, log=None):
-        self.log = log or Log().add_logger('Templater')
+        self.log = log or Log.add_logger('Templater')
         if self.__class__.ENVIRONMENT is None:
             loader = FileSystemLoader(str(self.TEMPLATE_DIR))
             self.__class__.ENVIRONMENT = Environment(loader=loader)

--- a/micropy/stubs/__init__.py
+++ b/micropy/stubs/__init__.py
@@ -2,6 +2,6 @@
 
 """Module for stub handling."""
 
-from .stubs import Stub, StubManager
+from .stubs import StubManager
 
-__all__ = ['Stub', 'StubManager']
+__all__ = ['StubManager']

--- a/micropy/stubs/__init__.py
+++ b/micropy/stubs/__init__.py
@@ -2,6 +2,6 @@
 
 """Module for stub handling."""
 
-from .stubs import Stub
+from .stubs import Stub, StubManager
 
-__all__ = ['Stub']
+__all__ = ['Stub', 'StubManager']

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -9,6 +9,107 @@ from micropy.logger import Log
 from micropy.utils import Validator
 
 
+class StubManager:
+    """Manages a collection of Stubs
+
+    Kwargs:
+        resource (str): Default resource path
+
+    Raises:
+        StubValidationError: a stub is missing a def file
+        StubValidationError: a stubs def file is not valid
+
+    Returns:
+        object: Instance of StubManager
+    """
+    _schema = Path(__file__).parent / 'schema.json'
+
+    def __init__(self, resource=None):
+        self._loaded = set()
+        self.resource = resource
+        self.log = Log.add_logger('Stubs', 'yellow')
+        if self.resource:
+            self.load_from(resource)
+
+    def __iter__(self):
+        return iter(self._loaded)
+
+    def __len__(self):
+        return len(self._loaded)
+
+    def _load(self, path, *args, **kwargs):
+        """Loads a stub"""
+        try:
+            self.validate(path)
+        except StubValidationError:
+            pass
+        else:
+            stub = Stub(path, *args, **kwargs)
+            self._loaded.add(stub)
+            return stub
+
+    def validate(self, path):
+        """Validates stubs"""
+        self.log.debug(f"Validating: {path}")
+        stub_info = path / 'modules.json'
+        val = Validator(self._schema)
+        try:
+            val.validate(stub_info)
+        except FileNotFoundError:
+            raise StubValidationError(
+                path, [f"{path.name} contains no modules.json file!"])
+        except Exception as e:
+            raise StubValidationError(path, str(e))
+
+    def is_valid(self, path):
+        """Check if stub is valid without raising an exception
+
+        Args:
+            path (str): path to stub
+
+        Returns:
+            bool: True if stub is valid
+        """
+        try:
+            self.validate(path)
+        except StubValidationError:
+            return False
+        else:
+            return True
+
+    def load_from(self, directory, *args, **kwargs):
+        """Load all stubs in a directory"""
+        dir_path = Path(str(directory)).resolve()
+        dirs = dir_path.iterdir()
+        stubs = [self._load(d, *args, **kwargs) for d in dirs]
+        return stubs
+
+    def add_from(self, source_dir, dest_dir):
+        """Add all stubs in a directory"""
+        dest_path = Path(str(dest_dir)).resolve()
+        return self.load_from(source_dir, copy_to=dest_dir)
+
+    def add(self, source, dest=None):
+        """Add stub(s) from source
+
+        Args:
+            source (str): path to stub(s)
+            dest (str, optional): path to copy stubs to.
+                Defaults to self.resource
+
+        Raises:
+            TypeError: No resource or destination provided
+        """
+        source_path = Path(str(source)).resolve()
+        _dest = dest or self.resource
+        if not _dest:
+            raise TypeError("No Stub Destination Provided!")
+        dest = Path(str(_dest)).resolve()
+        if not self.is_valid(source_path):
+            return self.load_from(source_path, copy_to=dest)
+        return self._load(source_path, copy_to=dest)
+
+
 class Stub:
     """Handles Stub Files
 
@@ -16,12 +117,10 @@ class Stub:
     :param Optional[str] copy_to: directory to copy stub to if it validates
 
     """
-    SCHEMA = Path(__file__).parent / 'schema.json'
 
     def __init__(self, path, copy_to=None, **kwargs):
         self.path = path.absolute()
-        self.log = Log().add_logger('Stubs', 'yellow')
-        self.validate(path)
+        self.log = Log.add_logger('Stubs', 'yellow')
         module = self.path / 'modules.json'
         info = json.load(module.open())
         device = info.pop(0)
@@ -33,32 +132,26 @@ class Stub:
         self.release = device.get('release')
         self.sysname = device.get('sysname')
         self.version = device.get('version')
+        self.name = f"{self.sysname}@{self.version}"
         if copy_to is not None:
             self.copy_to(copy_to)
 
-    def validate(self, path):
-        """Validates stubs"""
-        self.log.debug(f"Validating: {path}")
-        stub_info = path / 'modules.json'
-        val = Validator(self.SCHEMA)
-        try:
-            val.validate(stub_info)
-        except FileNotFoundError:
-            raise StubValidationError(
-                self, [f"{path.name} contains no modules.json file!"])
-        except Exception as e:
-            raise StubValidationError(self, str(e))
-
-    def copy_to(self, dest):
+    def copy_to(self, dest, name=None):
         """Copy stub to a directory"""
+        if not name:
+            dest = Path(dest) / self.path.name
         copytree(self.path, dest)
         self.path = dest
         return self
 
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def __hash__(self):
+        return hash(self.name)
+
     def __repr__(self):
-        return f"Stub(machine={self.machine}, nodename={self.nodename}, \
-                release={self.release}, sysname={self.sysname}, \
-                version={self.version}, modules={self.modules})"
+        return f"Stub(machine={self.machine}, nodename={self.nodename}, release={self.release}, sysname={self.sysname}, version={self.version})"
 
     def __str__(self):
-        return f"{self.sysname}@{self.version}"
+        return self.name

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -41,11 +41,13 @@ class StubManager:
         """Loads a stub"""
         try:
             self.validate(path)
-        except StubValidationError:
+        except StubValidationError as e:
+            self.log.debug(f"{path.name} failed to validate: {e.message}")
             pass
         else:
             stub = Stub(path, *args, **kwargs)
             self._loaded.add(stub)
+            self.log.debug(f"Loaded: {stub}")
             return stub
 
     def validate(self, path):
@@ -83,11 +85,6 @@ class StubManager:
         dirs = dir_path.iterdir()
         stubs = [self._load(d, *args, **kwargs) for d in dirs]
         return stubs
-
-    def add_from(self, source_dir, dest_dir):
-        """Add all stubs in a directory"""
-        dest_path = Path(str(dest_dir)).resolve()
-        return self.load_from(source_dir, copy_to=dest_dir)
 
     def add(self, source, dest=None):
         """Add stub(s) from source
@@ -145,13 +142,15 @@ class Stub:
         return self
 
     def __eq__(self, other):
-        return self.name == other.name
+        return self.name == getattr(other, 'name', None)
 
     def __hash__(self):
         return hash(self.name)
 
     def __repr__(self):
-        return f"Stub(machine={self.machine}, nodename={self.nodename}, release={self.release}, sysname={self.sysname}, version={self.version})"
+        return (f"Stub(machine={self.machine}, nodename={self.nodename},"
+                f" release={self.release}, sysname={self.sysname},"
+                f" version={self.version})")
 
     def __str__(self):
         return self.name

--- a/micropy/utils/pybwrapper.py
+++ b/micropy/utils/pybwrapper.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import rshell.main as rsh
+from rshell.pyboard import PyboardError
 
 from micropy.logger import Log
 
@@ -83,9 +84,14 @@ class PyboardWrapper:
         Args:
             path (str): path to file
         """
+        # TODO: Better Exception handling
         file_path = Path(str(path)).resolve()
         with self.repl():
-            out_bytes = self.pyboard.execfile(file_path)
+            try:
+                out_bytes = self.pyboard.execfile(file_path)
+            except PyboardError as e:
+                self.log.debug(f"Failed to run script on pyboard: {str(e)}")
+                raise Exception(str(e))
             out = str(out_bytes, 'utf-8')
             return out
 
@@ -119,5 +125,4 @@ class PyboardWrapper:
         }
         rsync_args.update(rsync)
         self.rsh.rsync(dir_path, str(dest_path), **rsync_args)
-        out_dir = dest_path / Path(path).name
-        return out_dir
+        return dest_path

--- a/tests/data/esp8266_invalid_stub/modules.json
+++ b/tests/data/esp8266_invalid_stub/modules.json
@@ -1,0 +1,10 @@
+[
+    {
+        "nodename": "esp32",
+        "release": "1.10.0"
+    },
+    {
+        "pathtofile": "/foobar/foo/bar.py",
+        "something": "bar"
+    }
+]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,14 +23,15 @@ def test_initial_stubs(mock_micropy_path):
     for stub in mp.STUBS:
         stub_dirs = stub_dir.iterdir()
         assert stub.path.exists()
-        assert stub.path in stub_dirs
+        assert stub.path.name in [p.name for p in stub_dirs]
     assert len(mp.STUBS) == len(list(stub_dir.iterdir()))
 
 
 def test_add_stub(mock_micropy, shared_datadir):
     """Test Adding Valid Stub"""
     stub_path = shared_datadir / 'esp8266_test_stub'
-    stub = mock_micropy.add_stub(stub_path)
-    assert stub in mock_micropy.STUBS
+    stubs = mock_micropy.STUBS
+    stub = stubs.add(stub_path, mock_micropy.STUB_DIR)
+    assert stub in list(mock_micropy.STUBS)
     assert stub.path in mock_micropy.STUB_DIR.iterdir()
     assert stub.path.exists()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,7 +6,7 @@ from micropy.project.template import TemplateProvider
 
 def test_project_init(mock_micropy, mock_cwd):
     """Test project setup"""
-    proj_stubs = mock_micropy.STUBS[:2]
+    proj_stubs = list(mock_micropy.STUBS)[:2]
     proj = Project("ProjName", proj_stubs)
     assert proj.path == mock_cwd / 'ProjName'
     assert proj.name == 'ProjName'
@@ -14,7 +14,7 @@ def test_project_init(mock_micropy, mock_cwd):
 
 def test_project_structure(mock_micropy, mock_cwd):
     """Test if project creates files"""
-    proj_stubs = mock_micropy.STUBS[:2]
+    proj_stubs = list(mock_micropy.STUBS)[:2]
     proj = Project("ProjName", proj_stubs)
     proj.create()
     templ_files = sorted([i.name for i in (

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -23,7 +23,7 @@ def test_bad_stub_validation(shared_datadir):
 def test_bad_stub(tmp_path):
     """should raise exception on invalid stub"""
     with pytest.raises(FileNotFoundError):
-        stubs.Stub(tmp_path)
+        stubs.stubs.Stub(tmp_path)
 
 
 def test_valid_stub(shared_datadir):

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -5,16 +5,31 @@ import pytest
 from micropy import exceptions, stubs
 
 
+def test_stub_validation(shared_datadir):
+    """should pass validation"""
+    stub_path = shared_datadir / 'esp8266_test_stub'
+    manager = stubs.StubManager()
+    manager.validate(stub_path)
+
+
+def test_bad_stub_validation(shared_datadir):
+    """should fail validation"""
+    stub_path = shared_datadir / 'esp8266_invalid_stub'
+    manager = stubs.StubManager()
+    with pytest.raises(exceptions.StubValidationError):
+        manager.validate(stub_path)
+
+
 def test_bad_stub(tmp_path):
     """should raise exception on invalid stub"""
-    with pytest.raises(exceptions.StubValidationError):
+    with pytest.raises(FileNotFoundError):
         stubs.Stub(tmp_path)
 
 
 def test_valid_stub(shared_datadir):
-    """should not raise any validation errors"""
+    """should have all attributes"""
     stub_path = shared_datadir / 'esp8266_test_stub'
-    stub = stubs.Stub(stub_path)
+    stub = stubs.stubs.Stub(stub_path)
     expect_module = {
         "file": "/stubs/esp8266_test_stub/micropython.py",
         "module": "micropython"
@@ -25,5 +40,46 @@ def test_valid_stub(shared_datadir):
     assert stub.version == "v1.9.4-8-ga9a3caad0 on 2018-05-11"
     assert stub.machine == "ESP module with ESP8266"
     assert stub.sysname == "esp8266"
+    assert stub.name == "esp8266@v1.9.4-8-ga9a3caad0 on 2018-05-11"
     assert expect_module in stub.modules
     assert str(stub) == "esp8266@v1.9.4-8-ga9a3caad0 on 2018-05-11"
+
+
+def test_add_single_stub(shared_datadir, tmp_path):
+    """should add a single stub"""
+    stub_path = shared_datadir / 'esp8266_test_stub'
+    manager = stubs.StubManager()
+    manager.add(stub_path, dest=tmp_path)
+    assert len(manager) == 1
+    assert stub_path.name in [d.name for d in tmp_path.iterdir()]
+
+
+def test_add_stubs_from_dir(datadir, tmp_path):
+    """should add all valid stubs in directory"""
+    manager = stubs.StubManager()
+    manager.add(datadir, dest=tmp_path)
+    assert len(manager) == 2
+    assert len(list(tmp_path.iterdir())) - 1 == len(manager)
+
+
+def test_add_with_resource(datadir, tmp_path):
+    """should not require dest kwarg"""
+    manager = stubs.StubManager(resource=tmp_path)
+    manager.add(datadir)
+    assert len(manager) == 2
+    # Subtract 1 cause tmp_path has datadir in it for some unrelated reason
+    # as in, before adding stubs
+    assert len(list(tmp_path.iterdir())) - 1 == len(manager)
+
+
+def test_add_no_resource_no_dest(datadir):
+    """should fail with typeerror"""
+    manager = stubs.StubManager()
+    with pytest.raises(TypeError):
+        manager.add(datadir)
+
+
+def test_loads_from_resource(datadir):
+    """should load from resource if provided"""
+    manager = stubs.StubManager(resource=datadir)
+    assert len(manager) == len(list(datadir.iterdir())) - 1

--- a/tests/test_stubs/bad_test_stub/modules.json
+++ b/tests/test_stubs/bad_test_stub/modules.json
@@ -1,0 +1,10 @@
+[
+    {
+        "nodename": "esp32",
+        "release": "1.10.0"
+    },
+    {
+        "pathtofile": "/foobar/foo/bar.py",
+        "something": "bar"
+    }
+]

--- a/tests/test_stubs/esp32_test_stub/modules.json
+++ b/tests/test_stubs/esp32_test_stub/modules.json
@@ -1,0 +1,17 @@
+[
+    {
+        "nodename": "esp32",
+        "release": "2.2.0-dev(9422289)",
+        "version": "v1.9.4-8-ga9a3caad0 on 2018-05-11",
+        "machine": "ESP module with ESP32",
+        "sysname": "esp32"
+    },
+    { "stubber": "1.1.2" },
+    { "file": "/stubs/esp8266_test_stub/math.py", "module": "math" },
+    {
+        "file": "/stubs/esp8266_test_stub/micropython.py",
+        "module": "micropython"
+    },
+    { "file": "/stubs/esp8266_test_stub/sys.py", "module": "sys" },
+    { "file": "/stubs/esp8266_test_stub/time.py", "module": "time" }
+]

--- a/tests/test_stubs/esp8266_test_stub/modules.json
+++ b/tests/test_stubs/esp8266_test_stub/modules.json
@@ -1,0 +1,17 @@
+[
+    {
+        "nodename": "esp8266",
+        "release": "2.2.0-dev(9422289)",
+        "version": "v1.9.4-8-ga9a3caad0 on 2018-05-11",
+        "machine": "ESP module with ESP8266",
+        "sysname": "esp8266"
+    },
+    { "stubber": "1.1.2" },
+    { "file": "/stubs/esp8266_test_stub/math.py", "module": "math" },
+    {
+        "file": "/stubs/esp8266_test_stub/micropython.py",
+        "module": "micropython"
+    },
+    { "file": "/stubs/esp8266_test_stub/sys.py", "module": "sys" },
+    { "file": "/stubs/esp8266_test_stub/time.py", "module": "time" }
+]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -8,7 +8,7 @@ from micropy.project.template import TemplateProvider
 
 
 def test_vscode_template(mock_micropy, tmp_path):
-    stubs = mock_micropy.STUBS[:3]
+    stubs = list(mock_micropy.STUBS)[:3]
     prov = TemplateProvider()
     prov.render_to('vscode', tmp_path, stubs=stubs)
     expected_path = tmp_path / '.vscode' / 'settings.json'
@@ -27,7 +27,7 @@ def test_vscode_template(mock_micropy, tmp_path):
 
 
 def test_pylint_template(mock_micropy, tmp_path):
-    stubs = mock_micropy.STUBS[:3]
+    stubs = list(mock_micropy.STUBS)[:3]
     prov = TemplateProvider()
     prov.render_to("pylint", tmp_path, stubs=stubs)
     expected_path = tmp_path / '.pylintrc'


### PR DESCRIPTION
Closes #6 
Closes #11 

* test(stubs): Initial Stub Manager Tests

* test: More StubManager Tests, Invalid Stub Test Data

* fix: Fix some issues with tests and exceptions

* feat(log): Remove need to reinstantiate Log before adding

No longer need to reinstantiate Log before adding a new one

* feat(stubs): Stub Manager Basic Implementation

* feat: StubManager Add, Unique Stubs

Added stub add handlers to StubManager, forced all stubs in StubManager to be unique

* feat: Began Replacing Micropy.STUBS with StubManager

* test: Updated Tests with Micropy.STUBS as StubManager

* test(stubs): Various Tests new StubManager add method

* fix: Loaded stubs are suppose to be an instance attribute

* feat(stubs): Use Unique Stub name as instance hash, not repr

* feat(stubs): Added resource kwarg to StubManager

An optional 'default' for destination kwargs

* feat(stubs): Add stubs from dir or path with one method

Handle both directories and stub paths with StubManager add method rather than add or add_from

* feat(stubs): StubManager Autoload from resource if provided