### PR TITLE
feat(stubs): Add Device Frozen Modules to Templates

### DIFF
--- a/micropy/project/template.py
+++ b/micropy/project/template.py
@@ -59,8 +59,10 @@ class CodeTemplate(Template):
     @property
     def context(self):
         """VScode Config Context"""
-        stubs = [str(s.path) for s in self.stubs]
-        stub_paths = json.dumps(stubs)
+        paths = [str(s.frozen) for s in self.stubs]
+        stubs = [str(s.stubs) for s in self.stubs]
+        paths.extend(stubs)
+        stub_paths = json.dumps(paths)
         ctx = {
             "stubs": self.stubs,
             "paths": stub_paths

--- a/micropy/project/template/.pylintrc
+++ b/micropy/project/template/.pylintrc
@@ -1,6 +1,6 @@
 [MASTER]
 # Loaded Stubs: {% for stub in stubs %} {{ stub }} {% endfor %}
-init-hook='import sys;{% for stub in stubs %}sys.path.insert(1, "{{ stub.path }}");{% endfor %}sys.path.insert(1,"./lib")'
+init-hook='import sys;{% for stub in stubs %}sys.path.insert(1, "{{ stub.frozen }}");sys.path.insert(1, "{{ stub.stubs }}");{% endfor %}sys.path.insert(1,"./lib")'
 
 [MESSAGES CONTROL]
 # Only show warnings with the listed confidence levels. Leave empty to show


### PR DESCRIPTION
Insert Device Specific frozen modules into template files for better Intellisense and auto completion as described in [Josverl/micropython-stubber](https://github.com/Josverl/micropython-stubber)