### PR TITLE
feat(project): Micropy Project Folder

### DIFF
--- a/micropy/project/template/.pylintrc
+++ b/micropy/project/template/.pylintrc
@@ -1,6 +1,6 @@
 [MASTER]
 # Loaded Stubs: {% for stub in stubs %} {{ stub }} {% endfor %}
-init-hook='import sys;{% for stub in stubs %}{% if stub.firmware %}sys.path.insert(1, "{{ stub.firmware.frozen }}");{% endif %}sys.path.insert(1, "{{ stub.frozen }}");sys.path.insert(1, "{{ stub.stubs }}");{% endfor %}sys.path.insert(1,"./lib")'
+init-hook='import sys;{% for path in paths %}sys.path.insert(1, "{{ path }}");{% endfor %}sys.path.insert(1,"./lib")'
 
 [MESSAGES CONTROL]
 # Only show warnings with the listed confidence levels. Leave empty to show

--- a/micropy/stubs/source.py
+++ b/micropy/stubs/source.py
@@ -147,7 +147,7 @@ class StubSource:
         """
         _path = path or self.location
         info_path = next(_path.rglob("info.json"), None)
-        path = Path(info_path.parent).resolve() if info_path else _path
+        path = Path(info_path.parent) if info_path else _path
         yield path
         if teardown:
             teardown()

--- a/micropy/utils/helpers.py
+++ b/micropy/utils/helpers.py
@@ -76,13 +76,13 @@ def ensure_existing_dir(path):
     Returns:
         object: pathlib.PurePath object
     """
-    _path = str(path)
-    path = Path(_path).resolve()
+    _path = Path(path)
+    path = _path.resolve()
     if not path.exists():
         raise NotADirectoryError(f"{_path} does not exist!")
     if not path.is_dir():
         raise NotADirectoryError(f"{_path} is not a directory!")
-    return path
+    return _path
 
 
 def is_existing_dir(path):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -19,6 +19,7 @@ def test_project_structure(mock_micropy, mock_cwd):
     proj.create()
     templ_files = sorted([i.name for i in (
         TemplateProvider.TEMPLATE_DIR).glob("**/*")])
-    proj_files = sorted([i.name for i in proj.path.glob("**/*")])
+    proj_files = sorted(
+        [i.name for i in proj.path.glob("**/*") if i.name != '.micropy'])
     print("Project Files:", proj_files)
     assert templ_files == proj_files

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -195,3 +195,25 @@ def test_stub_search(mocker, test_urls, shared_datadir, tmp_path, test_repo):
     res = results[0]
     assert res[0] == "esp32-micropython-1.11.0"
     assert not res[1]
+
+
+def test_stub_resolve_link(mock_mp_stubs, tmp_path):
+    """should create DeviceStub from symlink"""
+    stub = list(mock_mp_stubs.STUBS)[0]
+    link_path = tmp_path / 'stub_symlink'
+    linked_stub = stubs.stubs.DeviceStub.resolve_link(stub, link_path)
+    assert stub == linked_stub
+    assert stub.path != linked_stub.path
+    assert linked_stub.path.is_symlink()
+    assert linked_stub.path.resolve() == stub.path
+
+
+def test_manager_resolve_subresource(mock_mp_stubs, tmp_path):
+    """should create StubManager from subresource symlinks"""
+    test_stubs = list(mock_mp_stubs.STUBS)[:2]
+    subresource = tmp_path / 'stub_subresource'
+    subresource.mkdir()
+    manager = stubs.StubManager.resolve_subresource(test_stubs, subresource)
+    linked_stub = list(manager)[0]
+    assert linked_stub.path.is_symlink()
+    assert linked_stub in list(mock_mp_stubs.STUBS)


### PR DESCRIPTION
Instead of using the absolute paths to `$HOME/.micropy` folder in `settings.json` and `.pylintrc`, this creates a `<PROJECT_NAME>/.micropy` folder where used stubs are symlinked. This way, they can be referenced from `settings.json` as so:

```json
"setting_name" : [
    "${workspaceRoot}/.micropy/micropython/frozen",
    "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/frozen",
    "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/stubs"
]
```
> NOTE: This requires the VSCode Python extension (which you probably have anyways if your using this.) See microsoft/vscode#2809 for more details.

and from .pylint rc:

```python
init-hook='import sys;sys.path.insert(1, ".micropy/micropython/frozen");sys.path.insert(1, ".micropy/esp32-micropython-1.11.0/frozen");sys.path.insert(1, ".micropy/esp32-micropython-1.11.0/stubs")'
```

Using this method allows `settings.json` and `.pylintrc` to be VCS friendly, while only adding `.micropy/` to your `.gitignore`

Closes #19