### PR TITLE
feat(project): Micropy Project Info File

### DIFF
--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -89,15 +89,20 @@ def add(stub_name, force=False):
     """
     mp = MicroPy()
     mp.STUBS.verbose_log(True)
-    mp.log.title(f"Adding $[{stub_name}] to stubs...")
+    proj = Project('.', stub_manager=mp.STUBS)
+    mp.log.title(f"Adding $[{stub_name}] to stubs")
     try:
-        mp.STUBS.add(stub_name, force=force)
+        stub = mp.STUBS.add(stub_name, force=force)
     except exc.StubNotFound:
         mp.log.error(f"$[{stub_name}] could not be found!")
         sys.exit(1)
     except exc.StubError:
         mp.log.error(f"$[{stub_name}] is not a valid stub!")
         sys.exit(1)
+    else:
+        if proj.exists():
+            mp.log.title(f"Adding $[{stub.name}] to $[{proj.name}]")
+            proj.add_stub(stub)
 
 
 @stubs.command()

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -2,45 +2,94 @@
 
 """Hosts functionality relating to generation of user projects."""
 
+import json
 from pathlib import Path
 
 from micropy.logger import Log
+from micropy.main import MicroPy
 from micropy.project.template import TemplateProvider
-from micropy.stubs import StubManager
 
 
 class Project:
-    """Handles Project file generation and modification
+    """Handles Micropy Projects
 
-    :param str project_name: name of project
-    :param [micropy.stubs.Stub] stubs: Stubs to use in project
-
+    Args:
+        path (str): Path to project
+        stubs (Stub, optional): List of Stubs to use.
+            Defaults to None.
+        stub_manager (StubManager, optional): StubManager to source stubs.
+                Defaults to None.
     """
 
-    def __init__(self, project_name, stubs, **kwargs):
-        self.path = Path(project_name).resolve()
+    def __init__(self, path, stubs=None, stub_manager=None):
+        self.path = Path(path).resolve()
         self.data = self.path / '.micropy'
+        self.info_path = self.path / 'micropy.json'
+        self.stub_manager = stub_manager
+
         self.name = self.path.name
-        self._stubs = stubs
-        self.stubs = None
+        self.stubs = stubs
+
         self.log = Log.add_logger(self.name, show_title=False)
         template_log = Log.add_logger("Templater", parent=self.log)
         self.provider = TemplateProvider(log=template_log)
-        self.log.info(f"Initiating $[{self.name}]")
+
+    def load(self, **kwargs):
+        """Load existing project
+
+        Returns:
+            stubs: Project Stubs
+        """
+        data = json.loads(self.info_path.read_text())
+        _stubs = list(data.get("stubs"))
+        self.name = data.get("name", self.name)
+        self.stub_manager = kwargs.get("stub_manager", self.stub_manager)
+        self.stub_manager.verbose_log(True)
+        self.data.mkdir(exist_ok=True)
+        stubs = list(self.stub_manager.add(s) for s in _stubs)
+        self.stubs = list(
+            self.stub_manager.resolve_subresource(stubs, self.data))
+        self.log.success(f"\nProject Ready!")
+        return self.stubs
+
+    def exists(self):
+        """Whether this project exists
+
+        Returns:
+            bool: True if it exists
+        """
+        return self.info_path.exists()
 
     @property
     def context(self):
-        """Get complete project context"""
-        frozen = [s.frozen for s in self.stubs]
-        fware_mods = [s.firmware.frozen
-                      for s in self.stubs if s.firmware is not None]
-        stub_paths = [s.stubs for s in self.stubs]
-        paths = [*fware_mods, *frozen, *stub_paths]
+        """Get project template context"""
+        paths = []
+        if self.stubs:
+            frozen = [s.frozen for s in self.stubs]
+            fware_mods = [s.firmware.frozen
+                          for s in self.stubs if s.firmware is not None]
+            stub_paths = [s.stubs for s in self.stubs]
+            paths = [*fware_mods, *frozen, *stub_paths]
         return {
             "stubs": self.stubs,
             "paths": paths,
             "datadir": self.data
         }
+
+    @property
+    def info(self):
+        """Project Information"""
+        stubs = {s.name: s.stub_version for s in self.stubs}
+        return {
+            "name": self.name,
+            "stubs": stubs,
+        }
+
+    def to_json(self):
+        """Dumps project to data file"""
+        with self.info_path.open('w+') as f:
+            data = json.dumps(self.info)
+            f.write(data)
 
     def render_all(self):
         """Renders all project files"""
@@ -52,10 +101,33 @@ class Project:
 
     def create(self):
         """creates a new project"""
-        self.log.info("Rendering Project files...")
+        self.log.title(f"Initiating $[{self.name}]...")
         self.data.mkdir(exist_ok=True, parents=True)
-        self.stubs = StubManager.resolve_subresource(self._stubs, self.data)
+        self.stubs = list(
+            self.stub_manager.resolve_subresource(self.stubs, self.data))
+        self.log.info(
+            f"Stubs: $[{' '.join(str(s) for s in self.stubs)}]")
         self.log.debug(f"Generated Project Context: {self.context}")
+        self.log.info("Rendering Templates...")
         self.render_all()
+        self.to_json()
         self.log.success(f"Project Created!")
         return self.path.relative_to(Path.cwd())
+
+    @classmethod
+    def resolve(cls, path):
+        """Returns project from path if it exists
+
+        Args:
+            path (str): Path to test
+
+        Returns:
+            (Project|None): Project if it exists
+        """
+        path = Path(path).resolve()
+        proj = cls(path)
+        if proj.exists():
+            micropy = MicroPy()
+            micropy.log.title(f"Loading Project")
+            proj.load(stub_manager=micropy.STUBS)
+            return proj

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -34,6 +34,19 @@ class Project:
         template_log = Log.add_logger("Templater", parent=self.log)
         self.provider = TemplateProvider(log=template_log)
 
+    def _load_stubs(self, stubs):
+        """Loads stubs from info file
+
+        Args:
+            stub_list (dict): Dict of Stubs
+        """
+        for name, location in stubs.items():
+            _path = self.path / location
+            if Path(_path).exists():
+                yield self.stub_manager.add(_path)
+            else:
+                yield self.stub_manager.add(name)
+
     def load(self, **kwargs):
         """Load existing project
 
@@ -41,12 +54,12 @@ class Project:
             stubs: Project Stubs
         """
         data = json.loads(self.info_path.read_text())
-        _stubs = list(data.get("stubs"))
+        _stubs = data.get("stubs")
         self.name = data.get("name", self.name)
         self.stub_manager = kwargs.get("stub_manager", self.stub_manager)
         self.stub_manager.verbose_log(True)
         self.data.mkdir(exist_ok=True)
-        stubs = list(self.stub_manager.add(s) for s in _stubs)
+        stubs = list(self._load_stubs(_stubs))
         self.stubs = list(
             self.stub_manager.resolve_subresource(stubs, self.data))
         self.log.success(f"\nProject Ready!")

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -330,8 +330,7 @@ class StubManager:
                 results.append((p, p in installed))
         return sorted(results)
 
-    @classmethod
-    def resolve_subresource(cls, stubs, subresource):
+    def resolve_subresource(self, stubs, subresource):
         """Resolve or Create StubManager from list of stubs
 
         Args:
@@ -345,10 +344,11 @@ class StubManager:
             fware = stub.firmware
             if fware:
                 link = subresource / fware.path.name
-                Stub.resolve_link(fware, link)
+                fware = FirmwareStub.resolve_link(fware, link)
             link = subresource / stub.path.name
-            Stub.resolve_link(stub, link)
-        return cls(resource=subresource)
+            stub = DeviceStub.resolve_link(stub, link)
+            stub.firmware = fware
+            yield stub
 
 
 class Stub:
@@ -427,6 +427,8 @@ class DeviceStub(Stub):
 
         self.stubs = self.path / 'stubs'
         self.frozen = self.path / 'frozen'
+        stubber = self.info.get("stubber")
+        self.stub_version = stubber.get("version")
 
         self.firm_info = self.info.get("firmware")
         self.firmware = kwargs.get("firmware", None)

--- a/tests/data/project_test/micropy.json
+++ b/tests/data/project_test/micropy.json
@@ -1,0 +1,7 @@
+{
+    "name": "NewProject",
+    "stubs": {
+        "esp32-micropython-1.11.0": "1.2.0",
+        "esp8266-micropython-1.11.0": "1.2.0"
+    }
+}

--- a/tests/data/project_test/micropy.json
+++ b/tests/data/project_test/micropy.json
@@ -2,6 +2,7 @@
     "name": "NewProject",
     "stubs": {
         "esp32-micropython-1.11.0": "1.2.0",
-        "esp8266-micropython-1.11.0": "1.2.0"
+        "esp8266-micropython-1.11.0": "1.2.0",
+        "custom-stub": "../esp32_test_stub"
     }
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,9 @@ def test_cli_stubs_add(mocker, mock_micropy, shared_datadir,
     mocker.patch.object(cli, "MicroPy").return_value = mock_micropy
     mock_micropy.STUBS.add((shared_datadir / 'fware_test_stub'))
 
+    mock_proj = mocker.patch.object(cli, 'Project').return_value
+    mock_proj.exists.return_value = True
+
     mocker.spy(cli.sys, 'exit')
     err_spy = mocker.spy(mock_micropy.log, 'error')
     result = runner.invoke(cli.add, [str(test_invalid_stub.resolve())])
@@ -74,6 +77,7 @@ def test_cli_stubs_add(mocker, mock_micropy, shared_datadir,
     assert result.exit_code == 1
 
     result = runner.invoke(cli.add, [str(test_stub.resolve())])
+    assert mock_proj.add_stub.call_count == 1
     assert err_spy.call_count == 2
     assert result.exit_code == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,8 @@ def test_cli_init(mocker, mock_micropy, shared_datadir, mock_prompt, runner):
     assert result.exit_code == 1
     mock_micropy.STUBS = ["stub"]
     result = runner.invoke(cli.init, ["TestProject"])
-    mock_project.assert_called_once_with("TestProject", ["stub"])
+    mock_project.assert_called_once_with(
+        "TestProject", stubs=["stub"], stub_manager=mock_micropy.STUBS)
     mock_project.return_value.create.assert_called_once()
     assert result.exit_code == 0
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -36,9 +36,11 @@ def test_project_load(mocker, shared_datadir):
     mock_mp = mocker.patch.object(project.project, 'MicroPy').return_value
     proj_path = shared_datadir / 'project_test'
     proj = project.Project.resolve(proj_path)
+    expect_custom = proj.path / '../esp32_test_stub'
     mock_mp.STUBS.add.assert_any_call("esp32-micropython-1.11.0")
     mock_mp.STUBS.add.assert_any_call("esp8266-micropython-1.11.0")
-    assert mock_mp.STUBS.add.call_count == 2
+    mock_mp.STUBS.add.assert_any_call(expect_custom)
+    assert mock_mp.STUBS.add.call_count == 3
     mock_mp.STUBS.resolve_subresource.assert_called_once_with(
         mocker.ANY, proj.data)
     assert proj.data.exists()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import shutil
+
 from micropy import project
 from micropy.project.template import TemplateProvider
 
@@ -44,3 +46,23 @@ def test_project_load(mocker, shared_datadir):
     mock_mp.STUBS.resolve_subresource.assert_called_once_with(
         mocker.ANY, proj.data)
     assert proj.data.exists()
+
+
+def test_project_add_stub(mocker, shared_datadir, tmp_path):
+    """should add stub to project"""
+    mock_mp = mocker.patch.object(project.project, 'MicroPy').return_value
+    proj_path = tmp_path / 'tmp_project'
+    shutil.copytree((shared_datadir / 'project_test'), proj_path)
+    # Test Loaded
+    proj = project.Project.resolve(proj_path)
+    proj.add_stub("mock_stub")
+    mock_mp.STUBS.resolve_subresource.assert_called_with(
+        [mocker.ANY, mocker.ANY, mocker.ANY, "mock_stub"], proj.data)
+    shutil.rmtree(proj_path)
+    shutil.copytree((shared_datadir / 'project_test'), proj_path)
+    # Test Not loaded
+    proj = project.Project(proj_path, stub_manager=mock_mp.STUBS)
+    proj.add_stub("mock_stub")
+    mock_mp.STUBS.resolve_subresource.assert_called_with(
+        [mocker.ANY, mocker.ANY, mocker.ANY, "mock_stub"], proj.data)
+    assert mock_mp.STUBS.resolve_subresource.call_count == 3


### PR DESCRIPTION
Adds a `micropy.json` file to each project, used to resolve stubs in `.micropy/`

Unlike `.micropy/`, this file will be included in source control. Its similar in purpose to a `package.json`, but for stub packages instead. 

Although subject to (and likely will) change, here is currently simple schema:
```json
{
    "name": "NewProject",
    "stubs": {
        "esp32-micropython-1.11.0": "1.2.0",
        "custom-stub": "./local/path/on/VCS"
    }
}
```

Using this file, running `micropy` in a projects working directory will retrieve any needed stubs and generate the project local `.micropy/` directory. 

This effectively allows micropy to be near completely VCS compliant, and once its complete users will be able to match a given micropy workspace on Github (or wherever) after cloning by running `micropy` (similar to `npm` or `yarn`)
