### PR TITLE
feat(project): Make Templates Optional via CLI

### DIFF
--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -62,7 +62,6 @@ def init(path, name=None, template=None):
     """
     mp = MicroPy()
     mp.log.title("Creating New Project")
-    print(template)
     if not path:
         path = Path.cwd()
         default_name = path.name

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -3,6 +3,7 @@
 
 """MicropyCli Console Entrypoint"""
 import sys
+from pathlib import Path
 
 import click
 import questionary as prompt
@@ -43,8 +44,16 @@ def stubs():
 
 
 @cli.command(short_help="Create new Micropython Project")
-@click.argument('project_name', required=True)
-def init(project_name=""):
+@click.argument('path', required=False, default=None)
+@click.option('--name', '-n', required=False, default=None,
+              help="Project Name. Defaults to Path name.")
+@click.option('--template', '-t',
+              type=click.Choice(Project.TEMPLATES.keys()),
+              multiple=True,
+              required=False,
+              help=("Templates to generate for project."
+                    " Multiple options can be passed."))
+def init(path, name=None, template=None):
     """Create new Micropython Project
 
     \b
@@ -53,6 +62,17 @@ def init(project_name=""):
     """
     mp = MicroPy()
     mp.log.title("Creating New Project")
+    print(template)
+    if not path:
+        path = Path.cwd()
+        default_name = path.name
+        prompt_name = prompt.text("Project Name", default=default_name).ask()
+        name = prompt_name.strip()
+    if not template:
+        templ_choices = [Choice(str(val[1]), value=t)
+                         for t, val in Project.TEMPLATES.items()]
+        template = prompt.checkbox(
+            f"Choose any Templates to Generate", choices=templ_choices).ask()
     stubs = [Choice(str(s), value=s) for s in mp.STUBS]
     if not stubs:
         mp.log.error("You don't have any stubs!")
@@ -60,8 +80,12 @@ def init(project_name=""):
             "To add stubs to micropy, use $[micropy stubs add <STUB_NAME>]")
         sys.exit(1)
     stub_choices = prompt.checkbox(
-        "Which stubs would you like to use?", choices=stubs).ask()
-    project = Project(project_name, stubs=stub_choices, stub_manager=mp.STUBS)
+        f"Which stubs would you like to use?", choices=stubs).ask()
+    project = Project(path,
+                      name=name,
+                      templates=template,
+                      stubs=stub_choices,
+                      stub_manager=mp.STUBS)
     proj_relative = project.create()
     mp.log.title(f"Created $w[{project.name}] at $w[./{proj_relative}]")
 

--- a/micropy/project/template/pymakr.conf
+++ b/micropy/project/template/pymakr.conf
@@ -13,7 +13,9 @@
         "project.pymakr",
         "env",
         "venv",
-        ".python-version"
+        ".python-version",
+        ".micropy/",
+        "micropy.json"
     ],
     "fast_upload": false
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+
 import pytest
 from click.testing import CliRunner
 
@@ -51,11 +53,18 @@ def test_cli_init(mocker, mock_micropy, shared_datadir, mock_prompt, runner):
     result = runner.invoke(cli.init, ["TestProject"])
     assert result.exit_code == 1
     mock_micropy.STUBS = ["stub"]
-    result = runner.invoke(cli.init, ["TestProject"])
+    result = runner.invoke(cli.init, ["TestProject", "-t", "vscode"])
     mock_project.assert_called_once_with(
-        "TestProject", stubs=["stub"], stub_manager=mock_micropy.STUBS)
+        "TestProject", stubs=["stub"], stub_manager=mock_micropy.STUBS,
+        name=None, templates=('vscode', ))
     mock_project.return_value.create.assert_called_once()
     assert result.exit_code == 0
+    ptext_mock = mocker.patch.object(cli.prompt, 'text').return_value
+    ptext_mock.ask.return_value = "ProjectName"
+    result = runner.invoke(cli.init, ["-t", "vscode"])
+    mock_project.assert_called_with(
+        Path.cwd(), stubs=["stub"], stub_manager=mock_micropy.STUBS,
+        name="ProjectName", templates=('vscode', ))
 
 
 def test_cli_stubs_add(mocker, mock_micropy, shared_datadir,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -21,7 +21,8 @@ def test_project_structure(mock_mp_stubs, mock_cwd):
     mp = mock_mp_stubs
     proj_stubs = list(mp.STUBS)[:2]
     proj_path = mock_cwd / "ProjName"
-    proj = project.Project(proj_path, stubs=proj_stubs,
+    templates = ['vscode', 'pylint', 'bootstrap', 'pymakr']
+    proj = project.Project(proj_path, templates=templates, stubs=proj_stubs,
                            stub_manager=mp.STUBS)
     proj.create()
     templ_files = [i.name for i in (

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -21,7 +21,7 @@ def stub_context(mock_mp_stubs):
 
 def test_vscode_template(stub_context, shared_datadir, tmp_path):
     stubs, paths, ctx_paths = stub_context
-    prov = TemplateProvider()
+    prov = TemplateProvider(['vscode'])
     ctx_datadir = tmp_path / 'ctx_cata'
     ctx_datadir.mkdir(exist_ok=True)
     prov.render_to('vscode', tmp_path, stubs=stubs,
@@ -47,7 +47,7 @@ def test_pylint_template(stub_context, tmp_path):
     stubs, paths, ctx_paths = stub_context
     ctx_datadir = tmp_path / 'ctx_cata'
     ctx_datadir.mkdir(exist_ok=True)
-    prov = TemplateProvider()
+    prov = TemplateProvider(['pylint'])
     prov.render_to("pylint", tmp_path, stubs=stubs,
                    paths=ctx_paths, datadir=ctx_datadir)
     expected_path = tmp_path / '.pylintrc'
@@ -63,7 +63,7 @@ def test_pylint_template(stub_context, tmp_path):
 
 
 def test_generic_template(mock_mp_stubs, tmp_path):
-    prov = TemplateProvider()
+    prov = TemplateProvider(['bootstrap', 'pymakr'])
     prov.render_to('boot', tmp_path)
     expected_path = tmp_path / 'src' / 'boot.py'
     assert expected_path.exists()


### PR DESCRIPTION
Makes templates optional and allows users to select which to use.

Usage:

* Via Prompt:

```shell
micropy init

MicroPy  Creating New Project
? Project Name NewProject

? Choose any Templates to Generate                                                          
 » ○ VSCode Settings for Autocompletion/Intellisense 
   ○ Pymakr Configuration
   ○ Pylint Micropython Settings
   ○ main.py & boot.py files

```

* Via Flags

`micropy init -t vscode -t pymakr -t pylint`