### PR TITLE
fix: Unicode Error raised when logging on Windows

### DIFF
--- a/micropy/logger.py
+++ b/micropy/logger.py
@@ -108,7 +108,7 @@ class ServiceLog:
             sindex = _parts.index(w[1])
             parts[sindex] = (w[1], special)
             clean = msg.replace(f"${w[0]}[{w[1]}]", w[1])
-        clean = clean.encode('ascii', 'ignore').decode('unicode_escape')
+        clean = clean.encode('ascii', 'ignore').decode('utf-8')
         return (parts, clean)
 
     def get_parents(self, names=[]):


### PR DESCRIPTION
When running micropy in a windows environment, cleaning a message before writing it to the log raised a UnicodeDecodeError.

Closes #31