### PR TITLE
fix: ValueError raised after Creating Project in Windows

### DIFF
--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -23,7 +23,7 @@ class Project:
 
     def __init__(self, path, stubs=None, stub_manager=None):
         self._loaded = False
-        self.path = Path(path).resolve()
+        self.path = Path(path).absolute()
         self.data = self.path / '.micropy'
         self.info_path = self.path / 'micropy.json'
         self.stub_manager = stub_manager

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -10,7 +10,8 @@ def test_project_init(mock_mp_stubs, mock_cwd):
     """Test project setup"""
     mp = mock_mp_stubs
     proj_stubs = list(mp.STUBS)[:2]
-    proj = project.Project("ProjName", stubs=proj_stubs)
+    proj_path = mock_cwd / "ProjName"
+    proj = project.Project(proj_path, stubs=proj_stubs)
     assert proj.path == mock_cwd / 'ProjName'
     assert proj.name == 'ProjName'
 
@@ -19,7 +20,8 @@ def test_project_structure(mock_mp_stubs, mock_cwd):
     """Test if project creates files"""
     mp = mock_mp_stubs
     proj_stubs = list(mp.STUBS)[:2]
-    proj = project.Project("ProjName", stubs=proj_stubs,
+    proj_path = mock_cwd / "ProjName"
+    proj = project.Project(proj_path, stubs=proj_stubs,
                            stub_manager=mp.STUBS)
     proj.create()
     templ_files = [i.name for i in (


### PR DESCRIPTION
After creating a project, a ValueError is raised when attempting to get the relative path of the new
Project. This is fixed by setting the project path as an absolute path instead of resolving it.