### PR TITLE
feat(project): Retrieve and Stub Project Requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 .vscode
 !micropy/project/template/**/*
 !micropy/lib
+!tests/data/project_test/**/*

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ tox = "==3.7.0"
 micropy-cli = {editable = true,path = "."}
 wheel = "*"
 coveralls = "*"
+docutils = "==0.15"
 
 [packages]
 click = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ pytest-runner = "*"
 tox-pyenv = "*"
 pytest-mock = "*"
 pytest-datadir = "*"
-tox = "==3.7.0"
+tox = "*"
 micropy-cli = {editable = true,path = "."}
 wheel = "*"
 coveralls = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -32,3 +32,4 @@ colorama = {version = "*",sys_platform = "== 'win32'"}
 jinja2 = "*"
 requests = "*"
 tqdm = "*"
+requirements-parser = "*"

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -102,6 +102,10 @@ def install(packages, dev=False):
     intellisense, autocompletion, and linting for it.
 
     \b
+    If no packages are passed and a requirements.txt file is found,
+    then micropy will install all packages listed in it.
+
+    \b
     If the --dev flag is passed, then the packages are only
     added to micropy.json. They are not stubbed.
 
@@ -117,6 +121,14 @@ def install(packages, dev=False):
     if not project:
         mp.log.error("You are not currently in an active project!")
         sys.exit(1)
+    if not packages:
+        mp.log.title("Installing all Requirements")
+        reqs = project.add_from_requirements()
+        if not reqs:
+            mp.log.error("No requirements.txt file found!")
+            sys.exit(1)
+        mp.log.success("\nRequirements Installed!")
+        sys.exit(0)
     mp.log.title("Installing Packages")
     for pkg in packages:
         project.add_package(pkg, dev=dev)

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -89,6 +89,39 @@ def init(path, name=None, template=None):
     mp.log.title(f"Created $w[{project.name}] at $w[./{proj_relative}]")
 
 
+@cli.command(short_help="Install Project Requirements")
+@click.argument('packages', nargs=-1)
+@click.option('-d', '--dev', is_flag=True, default=False,
+              help=("Adds Package to dev requirements,"
+                    " but does not install stubs for it."))
+def install(packages, dev=False):
+    """Install Packages as Project Requirements
+
+    \b
+    Installing a package via micropy will stub it, enabling
+    intellisense, autocompletion, and linting for it.
+
+    \b
+    If the --dev flag is passed, then the packages are only
+    added to micropy.json. They are not stubbed.
+
+    \b
+    You can import installed packages just as you would
+    on your actual device:
+        \b
+        # main.py
+        import <package_name>
+    """
+    mp = MicroPy()
+    project = Project.resolve('.')
+    if not project:
+        mp.log.error("You are not currently in an active project!")
+        sys.exit(1)
+    mp.log.title("Installing Packages")
+    for pkg in packages:
+        project.add_package(pkg, dev=dev)
+
+
 @stubs.command(short_help="Add Stubs from package or path")
 @click.argument('stub_name', required=True)
 @click.option('-f', '--force', is_flag=True, default=False,

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -42,6 +42,8 @@ class Project:
         self.name = name or self.path.name
         self.stubs = stubs
 
+        self.requirements = self.path / 'requirements.txt'
+        self.dev_requirements = self.path / 'dev-requirements.txt'
         self.packages = {}
         self.dev_packages = {}
         self.pkg_data = self.data / self.name
@@ -220,6 +222,33 @@ class Project:
         self.load_packages()
         self.log.success("Package installed!")
         return packages
+
+    def _add_pkgs_from_file(self, path, **kwargs):
+        """Add packages listed in a file
+
+        Args:
+            path (str): path to file
+
+        Returns:
+            list of added reqs
+        """
+        if not path.exists():
+            return []
+        reqs = list(utils.iter_requirements(path))
+        for req in reqs:
+            self.add_package(req.line, **kwargs)
+        return reqs
+
+    def add_from_requirements(self):
+        """Add all packages in requirements.txt files
+
+        Returns:
+            List of all added requirements
+        """
+        reqs = self._add_pkgs_from_file(self.requirements)
+        dev_reqs = self._add_pkgs_from_file(self.dev_requirements, dev=True)
+        all_reqs = [*reqs, *dev_reqs]
+        return all_reqs if all_reqs else None
 
     def exists(self):
         """Whether this project exists

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -288,6 +288,29 @@ class Project:
             "dev-packages": self.dev_packages
         }
 
+    def _dump_requirements(self, packages, path):
+        """Dumps packages to file at path
+
+        Args:
+            packages (dict): dict of packages to dump
+            path (str): path to fiel
+        """
+        if not path.exists():
+            path.touch()
+        pkgs = [(f"{name}{spec}" if spec and spec != "*" else name)
+                for name, spec in packages.items()]
+        with path.open('r+') as f:
+            content = [c.strip() for c in f.readlines() if c.strip() != '']
+            _lines = sorted(set(pkgs) | set(content))
+            lines = [l + "\n" for l in _lines]
+            f.seek(0)
+            f.writelines(lines)
+
+    def to_requirements(self):
+        """Dumps requirements to .txt files"""
+        self._dump_requirements(self.packages, self.requirements)
+        self._dump_requirements(self.dev_packages, self.dev_requirements)
+
     def to_json(self):
         """Dumps project to data file"""
         with self.info_path.open('w+') as f:
@@ -306,6 +329,7 @@ class Project:
 
     def update_all(self):
         """Updates all project files"""
+        self.to_requirements()
         for t in self.provider.templates:
             self.provider.update(t, self.path, **self.context)
         return self.context

--- a/micropy/utils/helpers.py
+++ b/micropy/utils/helpers.py
@@ -16,10 +16,12 @@ from requests import exceptions as reqexc
 from requests import utils as requtil
 from tqdm import tqdm
 
+from micropy.lib.stubber.runOnPc import make_stub_files as stubgen
+
 __all__ = ["is_url", "get_url_filename",
            "ensure_existing_dir", "ensure_valid_url",
            "is_downloadable", "is_existing_dir",
-           "stream_download", "search_xml"]
+           "stream_download", "search_xml", "generate_stub"]
 
 
 def is_url(url):
@@ -183,3 +185,33 @@ def search_xml(url, node):
     _results = root.findall(f"./*/ns:{node}", namespace)
     results = [k.text for k in _results]
     return results
+
+
+def generate_stub(path, log_func=None):
+    """Create Stub from local .py file.
+
+    Args:
+        path (str): Path to file
+        log_func (func, optional): Callback function for logging.
+            Defaults to None.
+
+    Returns:
+        tuple: Tuple of file path and generated stub path.
+    """
+    mod_path = Path(stubgen.__file__).parent
+    # Monkeypatch print to prevent or wrap output
+    stubgen.print = lambda *args: None
+    if log_func:
+        stubgen.print = log_func
+    cfg_path = (mod_path / 'make_stub_files.cfg').absolute()
+    ctrl = stubgen.StandAloneMakeStubFile()
+    ctrl.update_flag = True
+    ctrl.config_fn = str(cfg_path)
+    file_path = Path(path).absolute()
+    stubbed_path = file_path.with_suffix('.pyi')
+    ctrl.files = [file_path]
+    ctrl.silent = True
+    ctrl.scan_options()
+    ctrl.run()
+    files = (file_path, stubbed_path)
+    return files

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,11 @@ testpaths = tests/
 
 [coverage:run]
 source = micropy
-omit = micropy/project/template/*
+omit =
+    micropy/project/template/*
+    micropy/lib/stubber/*
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	if __name__ == .__main__.:
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ REQUIRED = [
     'jsonschema',
     'jinja2',
     'requests',
-    'tqdm'
+    'tqdm',
+    'requirements-parser'
 ]
 
 EXTRAS = {}

--- a/tests/data/project_test/.pylintrc
+++ b/tests/data/project_test/.pylintrc
@@ -1,0 +1,3 @@
+[MASTER]
+# Loaded Stubs:  esp32-micropython-1.11.0  esp8266-micropython-1.11.0
+init-hook='import sys;sys.path.insert(1, ".micropy/micropython/frozen");sys.path.insert(1, ".micropy/micropython/frozen");sys.path.insert(1, ".micropy/esp32-micropython-1.11.0/frozen");sys.path.insert(1, ".micropy/esp8266-micropython-1.11.0/frozen");sys.path.insert(1, ".micropy/esp32-micropython-1.11.0/stubs");sys.path.insert(1, ".micropy/esp8266-micropython-1.11.0/stubs");sys.path.insert(1,"./lib")'

--- a/tests/data/project_test/.vscode/settings.json
+++ b/tests/data/project_test/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+    "python.linting.enabled": true,
+
+    // Loaded Stubs:  esp32-micropython-1.11.0  esp8266-micropython-1.11.0
+    "python.autoComplete.extraPaths": [
+        "${workspaceRoot}/.micropy/micropython/frozen",
+        "${workspaceRoot}/.micropy/micropython/frozen",
+        "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/frozen",
+        "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/frozen",
+        "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/stubs",
+        "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/stubs"
+    ],
+    "python.autoComplete.typeshedPaths": [
+        "${workspaceRoot}/.micropy/micropython/frozen",
+        "${workspaceRoot}/.micropy/micropython/frozen",
+        "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/frozen",
+        "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/frozen",
+        "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/stubs",
+        "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/stubs"
+    ],
+    "python.analysis.typeshedPaths": [
+        "${workspaceRoot}/.micropy/micropython/frozen",
+        "${workspaceRoot}/.micropy/micropython/frozen",
+        "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/frozen",
+        "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/frozen",
+        "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/stubs",
+        "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/stubs"
+    ],
+
+    "python.linting.pylintEnabled": true
+}

--- a/tests/data/project_test/micropy.json
+++ b/tests/data/project_test/micropy.json
@@ -5,6 +5,9 @@
         "esp8266-micropython-1.11.0": "1.2.0",
         "custom-stub": "../esp32_test_stub"
     },
+    "config": {
+        "vscode": true
+    },
     "packages": {
         "some_pkg": "*"
     },

--- a/tests/data/project_test/micropy.json
+++ b/tests/data/project_test/micropy.json
@@ -4,5 +4,11 @@
         "esp32-micropython-1.11.0": "1.2.0",
         "esp8266-micropython-1.11.0": "1.2.0",
         "custom-stub": "../esp32_test_stub"
+    },
+    "packages": {
+        "some_pkg": "*"
+    },
+    "dev-packages": {
+        "dev_pkg": "*"
     }
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,11 +112,17 @@ def test_cli_install(mocker, runner):
     mock_project = mocker.patch.object(cli, 'Project')
     mock_proj = mock_project.return_value
     mock_project.resolve.return_value = mock_proj
-
+    # Test Normal
     result = runner.invoke(cli.install, ["package", "--dev"])
     assert result.exit_code == 0
     mock_proj.add_package.assert_called_once_with("package", dev=True)
-
+    # Test from requirements
+    result = runner.invoke(cli.install, "")
+    assert result.exit_code == 0
+    mock_proj.add_from_requirements.return_value = None
+    result = runner.invoke(cli.install, "")
+    assert result.exit_code == 1
+    # Test no project found
     mock_project.resolve.return_value = None
     result = runner.invoke(cli.install, ["package"])
     assert result.exit_code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,3 +105,18 @@ def test_cli_stubs_search(mock_mp_stubs, mocker, runner):
     ]
     result = runner.invoke(cli.search, ["esp8266"])
     assert result.exit_code == 0
+
+
+def test_cli_install(mocker, runner):
+    """should install packages"""
+    mock_project = mocker.patch.object(cli, 'Project')
+    mock_proj = mock_project.return_value
+    mock_project.resolve.return_value = mock_proj
+
+    result = runner.invoke(cli.install, ["package", "--dev"])
+    assert result.exit_code == 0
+    mock_proj.add_package.assert_called_once_with("package", dev=True)
+
+    mock_project.resolve.return_value = None
+    result = runner.invoke(cli.install, ["package"])
+    assert result.exit_code == 1

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,8 +3,34 @@
 import shutil
 from pathlib import Path
 
+import pytest
+
 from micropy import project
 from micropy.project.template import TemplateProvider
+
+
+@pytest.fixture
+def mock_pkg(mocker, tmp_path):
+    """return mock package"""
+    tmp_pkg = tmp_path / 'tmp_pkg'
+    tmp_pkg.mkdir()
+    mock_tarbytes = mocker.patch.object(
+        project.project.utils, 'extract_tarbytes')
+    mocker.patch.object(
+        project.project.utils, 'get_package_meta')
+    mocker.patch.object(
+        project.project.utils, 'get_url_filename')
+    mocker.patch.object(
+        project.project.utils, 'stream_download')
+    mock_tarbytes.return_value = tmp_pkg
+    return tmp_pkg
+
+
+@pytest.fixture
+def mock_proj_dir(mocker, tmp_path, shared_datadir):
+    proj_path = tmp_path / 'tmp_project'
+    shutil.copytree((shared_datadir / 'project_test'), proj_path)
+    return proj_path
 
 
 def test_project_init(mock_mp_stubs, mock_cwd):
@@ -38,12 +64,19 @@ def test_project_structure(mock_mp_stubs, mock_cwd):
     assert expect_files == proj_files
 
 
-def test_project_load(mocker, shared_datadir):
+def test_project_load(mocker, shared_datadir, mock_pkg):
     mock_mp = mocker.patch.object(project.project, 'MicroPy').return_value
     mock_utils = mocker.patch.object(project.project, 'utils')
     mock_shutil = mocker.patch.object(project.project, 'shutil')
-    mock_utils.extract_tarbytes.return_value.rglob.return_value = (
-        Path("foobar.py"), Path("setup.py"))
+    mock_utils.extract_tarbytes.return_value.rglob.side_effect = [
+        iter([]),
+        iter([
+            Path("foobar.py"), Path("setup.py")]),
+        iter([
+            Path("pkg/__init__.py")]),
+        iter([
+            Path("foobar.py"), Path("setup.py")]),
+    ]
     mock_utils.generate_stub.return_value = (Path(
         "foobar.py"), Path("foobar.pyi"))
     proj_path = shared_datadir / 'project_test'
@@ -59,12 +92,15 @@ def test_project_load(mocker, shared_datadir):
     assert mock_shutil.copy2.call_count == 2
     mock_shutil.copy2.assert_called_with(
         Path("foobar.pyi"), (proj.pkg_data / "foobar.pyi"))
+    # Test package
+    proj.add_package('pkg')
+    mock_shutil.copytree.assert_called_once_with(
+        Path('pkg'), (proj.pkg_data / 'pkg'))
 
 
-def test_project_add_stub(mocker, shared_datadir, tmp_path):
+def test_project_add_stub(mocker, shared_datadir, tmp_path, mock_pkg):
     """should add stub to project"""
-    mock_mp = mocker.patch.object(project.project, 'MicroPy').return_value
-    mocker.patch.object(project.project, 'utils')
+    mocker.patch.object(project.project, 'MicroPy').return_value
     proj_path = tmp_path / 'tmp_project'
     shutil.copytree((shared_datadir / 'project_test'), proj_path)
     # Test Loaded
@@ -82,13 +118,11 @@ def test_project_add_stub(mocker, shared_datadir, tmp_path):
     assert mock_mp.STUBS.resolve_subresource.call_count == 3
 
 
-def test_project_add_pkg(mocker, shared_datadir, tmp_path):
+def test_project_add_pkg(mocker, mock_proj_dir, shared_datadir, tmp_path,
+                         mock_pkg):
     """should add package to requirements"""
     mock_mp = mocker.patch.object(project.project, "MicroPy").return_value
-    mocker.patch.object(project.project, 'utils')
-    proj_path = tmp_path / 'tmp_project'
-    shutil.copytree((shared_datadir / 'project_test'), proj_path)
-    proj = project.Project.resolve(proj_path)
+    proj = project.Project.resolve(mock_proj_dir)
     proj.add_package('mock_pkg')
     assert proj.packages['mock_pkg'] == "*"
     assert proj.add_package('mock_pkg') is None
@@ -96,13 +130,25 @@ def test_project_add_pkg(mocker, shared_datadir, tmp_path):
     proj.add_package('another_pkg==1.0.0', dev=True)
     assert proj.dev_packages['another_pkg'] == '==1.0.0'
     # Test Context
-    expect_proj_stubs = proj_path / '.micropy' / "NewProject"
+    expect_proj_stubs = mock_proj_dir / '.micropy' / "NewProject"
     mock_manager = mock_mp.STUBS
     mock_manager.resolve_subresource.return_value = [mocker.MagicMock()]
     mock_update = mocker.patch.object(
         project.project.TemplateProvider, 'update')
     proj = project.Project(
-        proj_path, stub_manager=mock_manager, name="NewProject")
+        mock_proj_dir, stub_manager=mock_manager, name="NewProject")
     proj.load()
     assert expect_proj_stubs in proj.context['paths']
     mock_update.assert_called_with('vscode', proj.path, **proj.context)
+
+
+def test_project_add_requirements(mocker, mock_proj_dir, mock_pkg):
+    """should add from requirements.txt"""
+    mock_mp = mocker.patch.object(project.project, "MicroPy").return_value
+    proj = project.Project.resolve(mock_proj_dir)
+    # Assert no reqs file
+    assert proj.add_from_requirements() is None
+    tmp_reqs = proj.path / 'requirements.txt'
+    tmp_reqs.touch()
+    tmp_reqs.write_text("micropy-cli==1.0.0")
+    assert next(iter(proj.add_from_requirements())).name == 'micropy-cli'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+
 import pytest
 import requests
 from jsonschema import ValidationError
@@ -113,3 +114,18 @@ def test_search_xml(mocker, shared_datadir, test_urls):
         "packages/esp32-micropython-1.10.0.tar.gz",
         "packages/esp32-micropython-1.11.0.tar.gz"
     ])
+
+
+def test_generate_stub(shared_datadir, tmp_path, mocker):
+    mock_stubber = mocker.patch.object(
+        utils.helpers.stubgen, 'StandAloneMakeStubFile').return_value
+    expect_path = tmp_path / 'foo.py'
+    expect_path.touch()
+    result = utils.generate_stub(expect_path)
+    mock_stubber.run.assert_called_once()
+    assert result == (expect_path, expect_path.with_suffix('.pyi'))
+    # Test print monkeypatch
+    print_mock = mocker.Mock(return_value=None)
+    result = utils.generate_stub(expect_path, log_func=print_mock)
+    utils.helpers.stubgen.print("hi")
+    assert print_mock.call_count >= 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -159,7 +159,7 @@ def test_get_package_meta(mocker):
         "url": "return-me.tar.gz"
     }
     mock_req.get.assert_called_once_with("https://pypi.org/pypi/foobar/json")
-    result = utils.get_package_meta("foobar", spec="0.0.0")
+    result = utils.get_package_meta("foobar", spec="==0.0.0")
     assert result == {
         "url": "early-version.tar.gz"
     }
@@ -176,3 +176,13 @@ def test_extract_tarbytes(mocker):
     mock_tarfile.open.assert_called_once_with(
         fileobj=io.BytesIO(test_bytes), mode="r:gz")
     mock_tar.extractall.assert_called_once_with("foobar")
+
+
+def test_iter_requirements(mocker, tmp_path):
+    """should iter requirements"""
+    tmp_file = tmp_path / 'tmp_reqs.txt'
+    tmp_file.touch()
+    tmp_file.write_text("micropy-cli==1.0.0")
+    result = next(utils.iter_requirements(tmp_file))
+    assert result.name == "micropy-cli"
+    assert result.specs == [('==', "1.0.0")]


### PR DESCRIPTION
Implements project requirement stubbing. While in a live project, executing:

`micropy add <micropython-module>` *ex: `micropy add blynklib`*

Will:
* add the module to your `micropy.json` file:

```json
{
  "name": "Project",
  "stubs": { "esp32-pycopy-1.11.0": "1.2.0" },
  "packages": {
    "blynklib": "*"
  },
  "dev-packages": {
    "micropy-cli": "*"
  }
}
```

* retrieve and stub the module, adding it to your `.micropy` folder:

```shell
.micropy
├── esp32-pycopy-1.11.0 -> $HOME.micropy/stubs/esp32-pycopy-1.11.0
├── Project
│   ├── blynklib.py
│   └── blynklib.pyi
└── pycopy -> $HOME/.micropy/stubs/pycopy
```

* and now the module can be used normally, without manually downloading it, adding it to git, etc.

![micropy-dep-stub](https://user-images.githubusercontent.com/5913808/61602931-2eb3f080-ac01-11e9-8273-6869ee7902eb.gif)
