### PR TITLE
fix(windows): Support User Level Directory Linking

### DIFF
--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import requirements
 
 from micropy import utils
+from micropy.exceptions import StubError
 from micropy.logger import Log
 from micropy.main import MicroPy
 from micropy.project.template import TemplateProvider
@@ -98,12 +99,9 @@ class Project:
             resource = set(
                 self.stub_manager.resolve_subresource(stubs, self.data))
         except OSError as e:
-            self.log.error(str(e))
-            self.log.info(
-                "MicroPy requires administrative privileges on Windows.")
-            self.log.info(
-                ("See $[https://github.com/BradenM/micropy-cli/issues/38]"
-                 " for more info."))
+            msg = "Failed to Create Stub Links!"
+            exc = StubError(message=msg)
+            self.log.error(str(e), exception=exc)
             sys.exit(1)
         else:
             return resource

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -407,9 +407,9 @@ class Stub:
             Stub: Stub from symlink
         """
         fware = stub.firmware
-        if link_path.is_symlink():
+        if utils.is_dir_link(link_path):
             return cls(link_path, firmware=fware)
-        link_path.symlink_to(stub.path, target_is_directory=True)
+        utils.create_dir_link(link_path, stub.path)
         return cls(link_path, firmware=fware)
 
     @property

--- a/micropy/utils/helpers.py
+++ b/micropy/utils/helpers.py
@@ -29,7 +29,8 @@ __all__ = ["is_url", "get_url_filename",
            "is_downloadable", "is_existing_dir",
            "stream_download", "search_xml",
            "generate_stub", "get_package_meta",
-           "extract_tarbytes", "iter_requirements"]
+           "extract_tarbytes", "iter_requirements",
+           "create_dir_link", "is_dir_link"]
 
 
 def is_url(url):
@@ -313,7 +314,8 @@ def create_dir_link(source, target):
             raise e
         # Fall back to directory junction
         cmd = ["MKLINK", "/J", str(source.absolute()), str(target.absolute())]
-        exit_code = subproc.call(cmd, shell=True)
+        exit_code = subproc.call(
+            cmd, shell=True, stdout=subproc.PIPE, stderr=subproc.PIPE)
         if exit_code:
             raise e
 


### PR DESCRIPTION
Allows `micropy-cli` to be executed in a shell without admin privs by falling back on `mklink` when attempting to create a link on windows systems.

As discussed in #44 

Closes #44