### PR TITLE
fix(hotfix): Remove workspaceRoot var from VSCode Settings

### DIFF
--- a/micropy/project/template.py
+++ b/micropy/project/template.py
@@ -133,12 +133,9 @@ class CodeTemplate(Template):
     @property
     def context(self):
         """VScode Config Context"""
-        _paths = self.paths
         if self.datadir:
-            root = Path("${workspaceRoot}")
-            _paths = [(root / p.relative_to(self.datadir.parent))
-                      for p in self.paths]
-        paths = [str(p) for p in _paths]
+            paths = [str(p.relative_to(self.datadir.parent))
+                     for p in self.paths]
         stub_paths = json.dumps(paths)
         ctx = {
             "stubs": self.stubs,

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -34,9 +34,7 @@ def test_vscode_template(stub_context, shared_datadir, tmp_path):
         lines = [l.strip() for l in f.readlines() if l]
         valid = [l for l in lines if "//" not in l[:2]]
     # Valid JSON?
-    root = Path("${workspaceRoot}")
-    expect_paths = [str((root / p.relative_to(tmp_path)))
-                    for p in ctx_paths]
+    expect_paths = [str(p.relative_to(tmp_path)) for p in ctx_paths]
     content = json.loads("\n".join(valid))
     assert sorted(expect_paths) == sorted(
         content["python.autoComplete.extraPaths"])
@@ -47,7 +45,7 @@ def test_vscode_template(stub_context, shared_datadir, tmp_path):
                 datadir=ctx_datadir)
     content = json.loads(expected_path.read_text())
     expect_paths.append(
-        str((root / (tmp_path / "foobar" / "foo.py").relative_to(tmp_path))))
+        str((tmp_path / "foobar" / "foo.py").relative_to(tmp_path)))
     assert sorted(expect_paths) == sorted(
         content["python.autoComplete.extraPaths"])
 


### PR DESCRIPTION
Variable is no longer parsed as of a recent release of ms-python, which is causing the vscode integration to fail.

**BREAKING CHANGE**: No longer compatible with `<=ms-python.python@2019.8.30787` VSCode Extension

Fixes #50
[MS-Python 2019.9.34474 breaks VSCode functionality](https://app.gitkraken.com/glo/board/XQ6dxflUvwAPjp-_/card/XYbODvPbxwAPcRDn)