### PR TITLE
fix: Fails to load Project if Template Files are Missing

### DIFF
--- a/micropy/project/template.py
+++ b/micropy/project/template.py
@@ -274,7 +274,11 @@ class TemplateProvider:
         """
         template = self.get(name, **kwargs)
         self.log.debug(f"Loaded: {str(template)}")
-        template.update(root_dir)
+        try:
+            template.update(root_dir)
+        except FileNotFoundError:
+            self.log.debug("Template does not exist!")
+            return self.render_to(name, root_dir, **kwargs)
         self.log.debug(f"Updated: {str(template)}")
         return template
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -47,6 +47,11 @@ def test_vscode_template(stub_context, shared_datadir, tmp_path, mock_checks):
         str((tmp_path / "foobar" / "foo.py").relative_to(tmp_path)))
     assert sorted(expect_paths) == sorted(
         content["python.autoComplete.extraPaths"])
+    # Test update with missing file
+    expected_path.unlink()  # delete file
+    prov.update('vscode', tmp_path, stubs=stubs, paths=ctx_paths,
+                datadir=ctx_datadir)
+    assert expected_path.exists()
 
 
 def test_pylint_template(stub_context, tmp_path):


### PR DESCRIPTION
Raises `FileNotFoundError` exception if one attempts to load a micropy project thats missing enabled template files. (Deleted/Ignored via VCS)