### PR TITLE
feat: Search/Retrieve Stubs Directly from micropy-stubs

### DIFF
--- a/micropy/data/sources.json
+++ b/micropy/data/sources.json
@@ -1,7 +1,6 @@
 [
     {
         "name": "Micropy Stubs",
-        "location": "https://micropy-stubs-prod.s3.amazonaws.com",
-        "path": "packages"
+        "source": "https://raw.githubusercontent.com/BradenM/micropy-stubs/master/source.json"
     }
 ]

--- a/micropy/utils/helpers.py
+++ b/micropy/utils/helpers.py
@@ -33,7 +33,8 @@ __all__ = ["is_url", "get_url_filename",
            "stream_download", "search_xml",
            "generate_stub", "get_package_meta",
            "extract_tarbytes", "iter_requirements",
-           "create_dir_link", "is_dir_link", "is_update_available"]
+           "create_dir_link", "is_dir_link",
+           "is_update_available", "get_cached_data"]
 
 
 def is_url(url):
@@ -49,6 +50,7 @@ def is_url(url):
     return scheme in ('http', 'https',)
 
 
+@cachier(stale_after=timedelta(days=1))
 def ensure_valid_url(url):
     """Ensure a url is valid
 
@@ -360,3 +362,10 @@ def is_update_available():
     if cur_version < latest:
         return str(latest)
     return False
+
+
+@cachier(stale_after=timedelta(days=3))
+def get_cached_data(url):
+    """Wrap requests with a short cache"""
+    source_data = requests.get(url).json()
+    return source_data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ mock_vscode_exts = [
 
 @pytest.fixture(autouse=True)
 def cleanup_data():
+    micropy.utils.ensure_valid_url.clear_cache()
     micropy.stubs.source.StubRepo.repos = set()
 
 

--- a/tests/data/test_repo.json
+++ b/tests/data/test_repo.json
@@ -1,15 +1,23 @@
 {
-    "source": {
-        "name": "Test Repo",
-        "location": "https://testsource.com",
-        "ref": "repo.json"
-    },
+    "name": "Test Repo",
+    "location": "www.google.com",
+    "source": "www.google.com/file.json",
+    "path": "tarball/pkg/",
     "packages": [
         {
-            "firmware": "micropython",
-            "device": "esp8266",
-            "version": "1.9.4",
-            "url": "https://testsource.com/packages/esp8266-micropython-1.9.4.tar.gz"
+            "name": "esp32-micropython-1.11.0",
+            "type": "device",
+            "sha256sum": "abc123"
+        },
+        {
+            "name": "esp32_LoBo-esp32_LoBo-3.2.24",
+            "type": "device",
+            "sha256sum": "123abc"
+        },
+        {
+            "name": "esp8266-micropython-1.9.4",
+            "type": "device",
+            "sha256sum": "1ab2c3"
         }
     ]
 }

--- a/tests/data/test_sources.json
+++ b/tests/data/test_sources.json
@@ -1,7 +1,6 @@
 [
     {
         "name": "Test Repo",
-        "location": "https://testsource.com",
-        "path": "packages"
+        "source": "https://google.com/repo.json"
     }
 ]

--- a/tests/test_stub_source.py
+++ b/tests/test_stub_source.py
@@ -41,7 +41,8 @@ def test_source_ready(shared_datadir, test_urls, tmp_path, mocker,
     remote_stub = source.get_source(test_urls['download'])
     with remote_stub.ready() as source_path:
         print(list(source_path.parent.iterdir()))
-        assert str(source_path) == str(expected_path)
+        assert (source_path / 'info.json').exists()
+        assert len(list(source_path.iterdir())) == 3
 
 
 def test_repo_from_json(shared_datadir, mocker):

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -184,12 +184,6 @@ def test_name_property(shared_datadir):
 def test_stub_search(mocker, test_urls, shared_datadir, tmp_path, test_repo):
     test_fware = shared_datadir / 'fware_test_stub'
     test_stub = shared_datadir / 'esp8266_test_stub'
-    mock_results = [
-        "packages/esp8266-micropython-1.9.4.tar.gz",
-        "packages/esp32-micropython-1.11.0.tar.gz"
-    ]
-    mock_search = mocker.patch.object(stubs.source.utils, 'search_xml')
-    mock_search.return_value = mock_results
     tmp_path = tmp_path / 'foobar'
     tmp_path.mkdir()
     manager = stubs.StubManager(resource=tmp_path, repos=[test_repo])

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -243,3 +243,17 @@ def test_load_firmware_first(mocker, tmp_path, shared_datadir):
     # Get First call args
     fargs, _ = mock_manager.call_args_list[0]
     assert fargs[0].location == test_fware
+
+
+def test_iter_by_firm_stubs(mocker):
+    """should iter stubs by firmware"""
+    firm_stub = mocker.MagicMock()
+    dev_stub = mocker.MagicMock()
+    dev_stub.firmware = firm_stub
+    unk_stub = mocker.MagicMock()
+    unk_stub.firmware = None
+    manager = stubs.StubManager()
+    manager._loaded = set([firm_stub, dev_stub, unk_stub])
+    manager._firmware = set([firm_stub])
+    stub_iter = list(manager.iter_by_firmware())
+    assert stub_iter == [(firm_stub, [dev_stub]), ('Unknown', [unk_stub])]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -251,3 +251,22 @@ def test_is_update_available(mocker):
     assert utils.helpers.is_update_available(ignore_cache=True) == '1.0.0'
     mocker.patch('micropy.__version__', '2.0.0')
     assert not utils.helpers.is_update_available(ignore_cache=True)
+
+
+def test_stream_download(mocker):
+    """Test stream download"""
+    mock_req = mocker.patch.object(utils.helpers, 'requests')
+    mock_stream = mocker.MagicMock()
+    mock_stream.headers = {
+        'content-length': '1000'
+    }
+    mock_req.get.return_value = mock_stream
+    tqdm_mock = mocker.patch.object(utils.helpers, 'tqdm')
+    utils.stream_download("https://someurl.com/file.ext")
+    expect_args = {
+        'unit_scale': True,
+        'unit_divisor': 1024,
+        'smoothing': 0.1,
+        'bar_format': mocker.ANY
+    }
+    tqdm_mock.assert_called_once_with(total=1000, unit='B', **expect_args)


### PR DESCRIPTION
Removes the need for an external AWS S3 bucket for hosting stub package archives and uses [micropy-stubs](https://github.com/BradenM/micropy-stubs) directly instead.

This closes BradenM/micropy-stubs#5