### PR TITLE
feat: Add Flag for Skipping Template Checks

### DIFF
--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -19,9 +19,11 @@ pass_mpy = click.make_pass_decorator(main.MicroPy, ensure=True)
 
 @click.group(invoke_without_command=True)
 @click.version_option()
+@click.option('--skip-checks', '-s', is_flag=True,
+              default=False, help='Skip Project Checks. Defaults to False.')
 @pass_mpy
 @click.pass_context
-def cli(ctx, mpy):
+def cli(ctx, mpy, skip_checks=False):
     """CLI Application for creating/managing Micropython Projects."""
     if ctx.invoked_subcommand is None:
         if not mpy.project:
@@ -33,6 +35,7 @@ def cli(ctx, mpy):
         log.info(f"Version $B[v{latest}] is now available")
         log.info(
             "You can update via: $[pip install --upgrade micropy-cli]\n")
+    mpy.RUN_CHECKS = not skip_checks
 
 
 @cli.group(short_help="Manage Micropy Stubs")
@@ -94,7 +97,8 @@ def init(mpy, path, name=None, template=None):
                       name=name,
                       templates=template,
                       stubs=stub_choices,
-                      stub_manager=mpy.stubs)
+                      stub_manager=mpy.stubs,
+                      run_checks=mpy.RUN_CHECKS)
     proj_relative = project.create()
     mpy.log.title(f"Created $w[{project.name}] at $w[./{proj_relative}]")
 

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -15,6 +15,7 @@ from micropy.stubs import StubManager, source
 
 class MicroPy:
     """Handles App State Management"""
+    RUN_CHECKS = True
 
     def __init__(self):
         self.log = Log.get_logger('MicroPy')
@@ -52,11 +53,12 @@ class MicroPy:
             (Project|None): Project if it exists
         """
         path = Path(path).absolute()
-        proj = Project(path)
+        proj = Project(path, run_checks=self.RUN_CHECKS)
         if proj.exists():
             if verbose:
                 self.log.title(f"Loading Project")
-            proj.load(stub_manager=self.stubs, verbose=verbose)
+            proj.load(stub_manager=self.stubs, verbose=verbose,
+                      run_checks=self.RUN_CHECKS)
             return proj
         return None
 

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -32,7 +32,7 @@ class Project:
     TEMPLATES = TemplateProvider.TEMPLATES
 
     def __init__(self, path, name=None, templates=[], stubs=None,
-                 stub_manager=None):
+                 stub_manager=None, **kwargs):
         self._loaded = False
         self.path = Path(path).absolute()
         self.data = self.path / '.micropy'
@@ -58,7 +58,8 @@ class Project:
             for key in self.config:
                 if key in templates:
                     self.config[key] = True
-            self.provider = TemplateProvider(templates, log=template_log)
+            self.provider = TemplateProvider(
+                templates, log=template_log, **kwargs)
 
     def _set_cache(self, key, value):
         """Set key in Project cache
@@ -180,7 +181,7 @@ class Project:
         self.name = data.get("name", self.name)
         self.config = data.get("config", self.config)
         templates = [k for k, v in self.config.items() if v]
-        self.provider = TemplateProvider(templates)
+        self.provider = TemplateProvider(templates, **kwargs)
         self.packages = data.get("packages", self.packages)
         self.dev_packages = data.get("dev-packages", self.dev_packages)
         self.stubs = kwargs.get('stubs', self.stubs)

--- a/micropy/project/template.py
+++ b/micropy/project/template.py
@@ -203,14 +203,17 @@ class TemplateProvider:
         'bootstrap': (['main', 'boot'], "main.py & boot.py files")
     }
 
-    def __init__(self, templates, log=None):
+    def __init__(self, templates, log=None, **kwargs):
         """Template Factory
 
         Args:
             templates ([str]): List of Templates to use
             log (callable, optional): Log instance to use.
                 Defaults to None. If none, creates a new one.
+            run_checks (bool, optional): Whether to run template checks.
+                Defaults to True.
         """
+        self.run_checks = kwargs.get('run_checks', True)
         self.template_names = set(chain.from_iterable(
             [self.TEMPLATES.get(t)[0] for t in templates]))
         self.files = {k: v for k, v in self._template_files.items()
@@ -251,9 +254,9 @@ class TemplateProvider:
         """
         template = self.get(name, **kwargs)
         self.log.debug(f"Loaded: {str(template)}")
-        if template.CHECKS:
+        if self.run_checks:
             self.log.debug(f"Verifying {template} requirements...")
-        template.run_checks()
+            template.run_checks()
         parent_dir.mkdir(exist_ok=True)
         out_dir = parent_dir / template.FILENAME
         out_dir.parent.mkdir(exist_ok=True, parents=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,7 @@ def test_cli_init(mocker, mock_mpy, shared_datadir, mock_prompt, runner):
     result = runner.invoke(cli.init, ["TestProject", "-t", "vscode"])
     mock_project.assert_called_once_with(
         "TestProject", stubs=["stub"], stub_manager=mock_mpy.stubs,
-        name=None, templates=('vscode', ))
+        name=None, templates=('vscode', ), run_checks=mock_mpy.RUN_CHECKS)
     mock_project.return_value.create.assert_called_once()
     assert result.exit_code == 0
     ptext_mock = mocker.patch.object(cli.prompt, 'text').return_value
@@ -77,6 +77,7 @@ def test_cli_init(mocker, mock_mpy, shared_datadir, mock_prompt, runner):
     result = runner.invoke(cli.init, ["-t", "vscode"])
     mock_project.assert_called_with(
         Path.cwd(), stubs=["stub"], stub_manager=mock_mpy.stubs,
+        run_checks=mock_mpy.RUN_CHECKS,
         name="ProjectName", templates=('vscode', ))
 
 


### PR DESCRIPTION
Allows user to skip template checks by passing a `--skip-checks` flag.

This deals with issues in which the user may not be initiating a project in the environment that it will be developed in.

Also works as temporary solution for #59 