### PR TITLE
refactor: Restructure Project Module

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -32,6 +32,7 @@ sphinx-click = "*"
 ptvsd = "*"
 tox-gh-actions = "*"
 pytest-xdist = "*"
+rope = "*"
 
 [packages]
 click = ">=7"
@@ -45,3 +46,4 @@ tqdm = "*"
 requirements-parser = "*"
 packaging = "*"
 cachier = "*"
+boltons = "*"

--- a/micropy/__init__.py
+++ b/micropy/__init__.py
@@ -16,5 +16,11 @@ VCS Compatibility
 and more.
 """
 
+from micropy import data, lib, project, stubs, utils
+
+from .main import MicroPy
+
 __author__ = """Braden Mars"""
 __version__ = '3.0.1'
+
+__all__ = ["MicroPy", "data", "lib", "project", "stubs", "utils"]

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -97,7 +97,7 @@ def init(mpy, path, name=None, template=None):
     project = Project(path, name=name)
     project.add(modules.StubsModule(mpy.stubs, stubs=stub_choices))
     project.add(modules.PackagesModule('requirements.txt'))
-    project.add(modules.PackagesModule('dev-requirements.txt', dev=True))
+    project.add(modules.DevPackagesModule('dev-requirements.txt'))
     project.add(modules.TemplatesModule(templates=template, run_checks=mpy.RUN_CHECKS))
     proj_relative = project.create()
     mpy.log.title(f"Created $w[{project.name}] at $w[./{proj_relative}]")
@@ -132,7 +132,7 @@ def install(mpy, packages, dev=False):
         import <package_name>
     """
     project = mpy.project
-    if not project:
+    if not project.exists:
         mpy.log.error("You are not currently in an active project!")
         sys.exit(1)
     if not packages:

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -216,7 +216,7 @@ def list(mpy):
     print_stubs(mpy.stubs.iter_by_firmware())
     mpy.verbose = False
     proj = mpy.project
-    if proj:
+    if proj.exists:
         mpy.log.title(f"Stubs used in {proj.name}:")
         mpy.log.info(f"Total: {len(proj.stubs)}")
         stubs = mpy.stubs.iter_by_firmware(stubs=proj.stubs)

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -12,7 +12,7 @@ from questionary import Choice
 import micropy.exceptions as exc
 from micropy import main, utils
 from micropy.logger import Log
-from micropy.project import Project
+from micropy.project import Project, modules
 
 pass_mpy = click.make_pass_decorator(main.MicroPy, ensure=True)
 
@@ -61,7 +61,7 @@ def stubs():
 @click.option('--name', '-n', required=False, default=None,
               help="Project Name. Defaults to Path name.")
 @click.option('--template', '-t',
-              type=click.Choice(Project.TEMPLATES.keys()),
+              type=click.Choice(modules.TemplatesModule.TEMPLATES.keys()),
               multiple=True,
               required=False,
               help=("Templates to generate for project."
@@ -81,8 +81,9 @@ def init(mpy, path, name=None, template=None):
         prompt_name = prompt.text("Project Name", default=default_name).ask()
         name = prompt_name.strip()
     if not template:
+        templates = modules.TemplatesModule.TEMPLATES.items()
         templ_choices = [Choice(str(val[1]), value=t)
-                         for t, val in Project.TEMPLATES.items()]
+                         for t, val in templates]
         template = prompt.checkbox(
             f"Choose any Templates to Generate", choices=templ_choices).ask()
     stubs = [Choice(str(s), value=s) for s in mpy.stubs]

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -26,7 +26,7 @@ pass_mpy = click.make_pass_decorator(main.MicroPy, ensure=True)
 def cli(ctx, mpy, skip_checks=False):
     """CLI Application for creating/managing Micropython Projects."""
     if ctx.invoked_subcommand is None:
-        if not mpy.project:
+        if not mpy.project.exists:
             return click.echo(ctx.get_help())
     latest = utils.is_update_available()
     if latest:
@@ -171,7 +171,7 @@ def add(mpy, stub_name, force=False):
     Checkout the docs on Github for more info.
     """
     mpy.stubs.verbose_log(True)
-    proj = Project('.', stub_manager=mpy.stubs)
+    proj = mpy.project
     mpy.log.title(f"Adding $[{stub_name}] to stubs")
     try:
         stub = mpy.stubs.add(stub_name, force=force)
@@ -215,7 +215,7 @@ def list(mpy):
     mpy.log.info(f"Total: {len(mpy.stubs)}")
     print_stubs(mpy.stubs.iter_by_firmware())
     mpy.verbose = False
-    proj = mpy.resolve_project('.')
+    proj = mpy.project
     if proj:
         mpy.log.title(f"Stubs used in {proj.name}:")
         mpy.log.info(f"Total: {len(proj.stubs)}")

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -98,6 +98,7 @@ def init(mpy, path, name=None, template=None):
     project.add(modules.TemplatesModule(templates=template, run_checks=mpy.RUN_CHECKS))
     project.add(modules.StubsModule(mpy.stubs, stubs=stub_choices))
     project.add(modules.PackagesModule('requirements.txt'))
+    project.add(modules.PackagesModule('dev-requirements.txt', dev=True))
     proj_relative = project.create()
     mpy.log.title(f"Created $w[{project.name}] at $w[./{proj_relative}]")
 

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -95,10 +95,10 @@ def init(mpy, path, name=None, template=None):
     stub_choices = prompt.checkbox(
         f"Which stubs would you like to use?", choices=stubs).ask()
     project = Project(path, name=name)
-    project.add(modules.TemplatesModule(templates=template, run_checks=mpy.RUN_CHECKS))
     project.add(modules.StubsModule(mpy.stubs, stubs=stub_choices))
     project.add(modules.PackagesModule('requirements.txt'))
     project.add(modules.PackagesModule('dev-requirements.txt', dev=True))
+    project.add(modules.TemplatesModule(templates=template, run_checks=mpy.RUN_CHECKS))
     proj_relative = project.create()
     mpy.log.title(f"Created $w[{project.name}] at $w[./{proj_relative}]")
 
@@ -182,7 +182,7 @@ def add(mpy, stub_name, force=False):
         mpy.log.error(f"$[{stub_name}] is not a valid stub!")
         sys.exit(1)
     else:
-        if proj.exists():
+        if proj.exists:
             mpy.log.title(f"Adding $[{stub.name}] to $[{proj.name}]")
             proj.add_stub(stub)
 

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -94,12 +94,10 @@ def init(mpy, path, name=None, template=None):
         sys.exit(1)
     stub_choices = prompt.checkbox(
         f"Which stubs would you like to use?", choices=stubs).ask()
-    project = Project(path,
-                      name=name,
-                      templates=template,
-                      stubs=stub_choices,
-                      stub_manager=mpy.stubs,
-                      run_checks=mpy.RUN_CHECKS)
+    project = Project(path, name=name)
+    project.add(modules.TemplatesModule(templates=template, run_checks=mpy.RUN_CHECKS))
+    project.add(modules.StubsModule(mpy.stubs, stubs=stub_choices))
+    project.add(modules.PackagesModule('requirements.txt'))
     proj_relative = project.create()
     mpy.log.title(f"Created $w[{project.name}] at $w[./{proj_relative}]")
 

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -137,7 +137,7 @@ def install(mpy, packages, dev=False):
         sys.exit(1)
     if not packages:
         mpy.log.title("Installing all Requirements")
-        reqs = project.add_from_requirements()
+        reqs = project.add_from_file(dev=dev)
         if not reqs:
             mpy.log.error("No requirements.txt file found!")
             sys.exit(1)

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from micropy import data, utils
 from micropy.lib.stubber import process as stubber
 from micropy.logger import Log
-from micropy.project import Project
+from micropy.project import Project, modules
 from micropy.stubs import StubManager, source
 
 
@@ -53,12 +53,16 @@ class MicroPy:
             (Project|None): Project if it exists
         """
         path = Path(path).absolute()
-        proj = Project(path, run_checks=self.RUN_CHECKS)
-        if proj.exists():
+        proj = Project(path)
+        proj.add(modules.StubsModule(self.stubs))
+        proj.add(modules.TemplatesModule())
+        proj.add(modules.PackagesModule('requirements.txt'))
+        proj.add(modules.PackagesModule(
+            'dev-requirements.txt', name='dev-packages'))
+        if proj.exists:
             if verbose:
                 self.log.title(f"Loading Project")
-            proj.load(stub_manager=self.stubs, verbose=verbose,
-                      run_checks=self.RUN_CHECKS)
+            proj.load(run_checks=self.RUN_CHECKS)
             return proj
         return None
 

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -64,7 +64,7 @@ class MicroPy:
                 self.log.title(f"Loading Project")
             proj.load()
             return proj
-        return None
+        return proj
 
     def create_stubs(self, port, verbose=False):
         """Create and add stubs from Pyboard

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -55,14 +55,14 @@ class MicroPy:
         path = Path(path).absolute()
         proj = Project(path)
         proj.add(modules.StubsModule(self.stubs))
-        proj.add(modules.TemplatesModule())
+        proj.add(modules.TemplatesModule(run_checks=self.RUN_CHECKS))
         proj.add(modules.PackagesModule('requirements.txt'))
         proj.add(modules.PackagesModule(
             'dev-requirements.txt', name='dev-packages'))
         if proj.exists:
             if verbose:
                 self.log.title(f"Loading Project")
-            proj.load(run_checks=self.RUN_CHECKS)
+            proj.load()
             return proj
         return None
 

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -58,7 +58,7 @@ class MicroPy:
         proj.add(modules.TemplatesModule(run_checks=self.RUN_CHECKS))
         proj.add(modules.PackagesModule('requirements.txt'))
         proj.add(modules.PackagesModule(
-            'dev-requirements.txt', name='dev-packages'))
+            'dev-requirements.txt', dev=True))
         if proj.exists:
             if verbose:
                 self.log.title(f"Loading Project")

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -55,10 +55,10 @@ class MicroPy:
         path = Path(path).absolute()
         proj = Project(path)
         proj.add(modules.StubsModule(self.stubs))
-        proj.add(modules.TemplatesModule(run_checks=self.RUN_CHECKS))
         proj.add(modules.PackagesModule('requirements.txt'))
         proj.add(modules.PackagesModule(
             'dev-requirements.txt', dev=True))
+        proj.add(modules.TemplatesModule(run_checks=self.RUN_CHECKS))
         if proj.exists:
             if verbose:
                 self.log.title(f"Loading Project")

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -56,8 +56,8 @@ class MicroPy:
         proj = Project(path)
         proj.add(modules.StubsModule(self.stubs))
         proj.add(modules.PackagesModule('requirements.txt'))
-        proj.add(modules.PackagesModule(
-            'dev-requirements.txt', dev=True))
+        proj.add(modules.DevPackagesModule(
+            'dev-requirements.txt'))
         proj.add(modules.TemplatesModule(run_checks=self.RUN_CHECKS))
         if proj.exists:
             if verbose:

--- a/micropy/project/__init__.py
+++ b/micropy/project/__init__.py
@@ -2,6 +2,7 @@
 
 """Module for generating/managing projects."""
 
+from . import modules
 from .project import Project
 
-__all__ = ['Project']
+__all__ = ['Project', 'modules']

--- a/micropy/project/modules/__init__.py
+++ b/micropy/project/modules/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+"""Project Modules"""
+
+
+from .modules import ProjectModule
+from .packages import PackagesModule
+from .stubs import StubsModule
+from .templates import TemplatesModule
+
+__all__ = ['TemplatesModule', 'PackagesModule', 'StubsModule', 'ProjectModule']

--- a/micropy/project/modules/__init__.py
+++ b/micropy/project/modules/__init__.py
@@ -4,8 +4,8 @@
 
 
 from .modules import ProjectModule
-from .packages import PackagesModule
+from .packages import DevPackagesModule, PackagesModule
 from .stubs import StubsModule
 from .templates import TemplatesModule
 
-__all__ = ['TemplatesModule', 'PackagesModule', 'StubsModule', 'ProjectModule']
+__all__ = ['TemplatesModule', 'PackagesModule', 'StubsModule', 'ProjectModule', 'DevPackagesModule']

--- a/micropy/project/modules/modules.py
+++ b/micropy/project/modules/modules.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+import abc
+
+"""Project Packages Module Abstract Implementation"""
+
+
+class ProjectModule(metaclass=abc.ABCMeta):
+
+    @property
+    def parent(self):
+        return self._parent
+
+    @parent.setter
+    def parent(self, parent):
+        self._parent = parent
+
+    @abc.abstractproperty
+    def config(self):
+        pass
+
+    @abc.abstractmethod
+    def load(self):
+        pass
+
+    @abc.abstractmethod
+    def create(self):
+        pass
+
+    @abc.abstractmethod
+    def update(self):
+        pass
+
+    def add(self, component):
+        pass
+
+    def remove(self, component):
+        pass

--- a/micropy/project/modules/modules.py
+++ b/micropy/project/modules/modules.py
@@ -18,7 +18,8 @@ class ProjectModule(metaclass=abc.ABCMeta):
     def parent(self, parent):
         if parent:
             for hook in ProjectModule._hooks:
-                setattr(parent, hook.__name__, partial(hook, self))
+                if not hasattr(parent, hook.__name__) and hasattr(self, hook.__name__):
+                    setattr(parent, hook.__name__, partial(hook, self))
         self._parent = parent
 
     @property

--- a/micropy/project/modules/modules.py
+++ b/micropy/project/modules/modules.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import abc
+from functools import partial, wraps
 
 """Project Packages Module Abstract Implementation"""
 
 
 class ProjectModule(metaclass=abc.ABCMeta):
+
+    _hooks = []
 
     @property
     def parent(self):
@@ -13,7 +16,22 @@ class ProjectModule(metaclass=abc.ABCMeta):
 
     @parent.setter
     def parent(self, parent):
+        if parent:
+            for hook in ProjectModule._hooks:
+                setattr(parent, hook.__name__, partial(hook, self))
         self._parent = parent
+
+    @property
+    def hooks(self):
+        return self._hooks
+
+    @classmethod
+    def method_hook(cls, func):
+        cls._hooks.append(func)
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        return wrapper
 
     @abc.abstractproperty
     def config(self):

--- a/micropy/project/modules/modules.py
+++ b/micropy/project/modules/modules.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
 
 import abc
+import inspect
 from functools import wraps
+
+from micropy import utils
+from micropy.logger import Log
 
 """Project Packages Module Abstract Implementation"""
 
 
 class ProjectModule(metaclass=abc.ABCMeta):
 
-    _hooks = set()
+    _hooks = []
 
     @property
     def parent(self):
@@ -41,15 +45,67 @@ class ProjectModule(metaclass=abc.ABCMeta):
         pass
 
     @classmethod
-    def hook(cls, func, name=None):
-        name = name or func.__name__
-        cls._hooks.add(name)
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-        return wrapper
+    def hook(cls, *args, **kwargs):
+        def _hook(func):
+            name = kwargs.get('name', func.__name__)
+            hook = next((i for i in cls._hooks if i._name == name), None)
+            if not hook:
+                hook = HookProxy(name)
+                ProjectModule._hooks.append(hook)
+            hook.add_method(func, **kwargs)
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+            return wrapper
+        return _hook
 
     def resolve_hook(self, name):
+        _hook = None
         for hook in self._hooks:
-            if hasattr(self, name):
-                return getattr(self, name)
+            if hook._name == name:
+                _hook = hook
+                _hook.add_instance(self)
+        return _hook
+
+
+class HookProxy:
+    def __init__(self, name):
+        self.methods = []
+        self.instances = []
+        self._name = name
+        self.log = Log.add_logger(str(self))
+
+    def __call__(self, *args, **kwargs):
+        for method, name in self.methods:
+            _name = self.get_name(method, kwargs)
+            if name == _name:
+                _class = utils.get_class_that_defined_method(method)
+                instance = next((i for i in self.instances if isinstance(i, _class)))
+                self.log.debug(f"{self._name} proxied to [{name}@{instance}]")
+                return getattr(instance, method.__name__)(*args, **kwargs)
+
+    def __str__(self):
+        name = f"HookProxy({self._name})"
+        return name
+
+    def __repr__(self):
+        name = f"HookProxy(name={self._name}, methods=[{self.methods}])"
+        return name
+
+    def add_method(self, func, **kwargs):
+        name = self.get_name(func, kwargs)
+        hook = (func, name)
+        self.methods.append(hook)
+        self.log.debug(f"Method added to proxy: {hook}")
+        return hook
+
+    def add_instance(self, inst):
+        return self.instances.append(inst)
+
+    def get_name(self, func, params):
+        sig = inspect.signature(func)
+        _default = {p.name: p.default for p in sig.parameters.values() if p.kind ==
+                    p.POSITIONAL_OR_KEYWORD and p.default is not p.empty}
+        params = {**_default, **params}
+        name = f"_hook__{self._name}__{'__'.join(f'{k}_{v}' for k, v in params.items())}"
+        return name

--- a/micropy/project/modules/packages.py
+++ b/micropy/project/modules/packages.py
@@ -38,10 +38,10 @@ class PackagesModule(ProjectModule):
 
     @property
     def context(self):
-        _paths = set(self.parent._context.get('paths', []))
+        _paths = self.parent._context.get('paths', set())
         _paths.add(self.pkg_path)
         return {
-            'paths': list(_paths)
+            'paths': _paths
         }
 
     def _fetch_package(self, url):

--- a/micropy/project/modules/packages.py
+++ b/micropy/project/modules/packages.py
@@ -98,7 +98,7 @@ class PackagesModule(ProjectModule):
         self.log.success("Package installed!")
         return self.packages
 
-    def load(self):
+    def load(self, **kwargs):
         """Retrieves and stubs project requirements"""
         self.pkg_path.mkdir(exist_ok=True)
         pkg_keys = set(self.packages.keys())

--- a/micropy/project/modules/packages.py
+++ b/micropy/project/modules/packages.py
@@ -76,7 +76,7 @@ class PackagesModule(ProjectModule):
                 shutil.copy2(file, (self.pkg_path / file.name))
                 shutil.copy2(stub, (self.pkg_path / stub.name))
 
-    @ProjectModule.method_hook
+    @ProjectModule.hook
     def add_package(self, package, dev=False):
         """Add requirement to project
 

--- a/micropy/project/modules/packages.py
+++ b/micropy/project/modules/packages.py
@@ -14,14 +14,11 @@ from micropy.project.modules import ProjectModule
 
 class PackagesModule(ProjectModule):
 
-    def __init__(self, path, packages=None, dev=False, **kwargs):
+    def __init__(self, path, packages=None, **kwargs):
         self._path = Path(path)
         self._loaded = False
-        self.is_dev = dev
         packages = packages or {}
-        if self.is_dev:
-            packages['micropy-cli'] = '*'
-        self.name = "dev-packages" if self.is_dev else "packages"
+        self.name = "packages"
         self.packages = {**packages}
 
     @property
@@ -76,8 +73,8 @@ class PackagesModule(ProjectModule):
                 shutil.copy2(file, (self.pkg_path / file.name))
                 shutil.copy2(stub, (self.pkg_path / stub.name))
 
-    @ProjectModule.hook
-    def add_package(self, package, dev=False):
+    @ProjectModule.hook()
+    def add_package(self, package, dev=False, **kwargs):
         """Add requirement to project
 
         Args:
@@ -87,8 +84,6 @@ class PackagesModule(ProjectModule):
         Returns:
             dict: Dictionary of packages
         """
-        if self.is_dev and not dev:
-            return None
         pkg = next(requirements.parse(package))
         self.log.info(f"Adding $[{pkg.name}] to requirements...")
         if self.packages.get(pkg.name, None):
@@ -101,7 +96,7 @@ class PackagesModule(ProjectModule):
         self.log.success("Package installed!")
         return self.packages
 
-    def load(self, **kwargs):
+    def load(self, fetch=True, **kwargs):
         """Retrieves and stubs project requirements"""
         self.pkg_path.mkdir(exist_ok=True)
         pkg_keys = set(self.packages.keys())
@@ -111,12 +106,12 @@ class PackagesModule(ProjectModule):
             new_pkgs = new_pkgs - set(pkg_cache)
         pkgs = [(name, s)
                 for name, s in self.packages.items() if name in new_pkgs]
-        if pkgs and not self._loaded and not self.is_dev:
-            self.log.title("Fetching Requirements")
-        for name, spec in pkgs:
-            meta = utils.get_package_meta(name, spec=spec)
-            tar_url = meta['url']
-            if not self.is_dev:
+        if fetch:
+            if pkgs and not self._loaded:
+                self.log.title("Fetching Requirements")
+            for name, spec in pkgs:
+                meta = utils.get_package_meta(name, spec=spec)
+                tar_url = meta['url']
                 self._fetch_package(tar_url)
         self.update()
         self.parent._set_cache('pkg_loaded', list(pkg_keys))
@@ -136,3 +131,18 @@ class PackagesModule(ProjectModule):
             lines = [l + "\n" for l in _lines]
             f.seek(0)
             f.writelines(lines)
+
+
+class DevPackagesModule(PackagesModule):
+
+    def __init__(self, path, **kwargs):
+        super().__init__(path, **kwargs)
+        self.packages.update({'micropy-cli': '*'})
+        self.name = "dev-packages"
+
+    def load(self, *args, **kwargs):
+        return super().load(*args, **kwargs, fetch=False)
+
+    @ProjectModule.hook(dev=True)
+    def add_package(self, package, **kwargs):
+        return super().add_package(package, **kwargs)

--- a/micropy/project/modules/packages.py
+++ b/micropy/project/modules/packages.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+"""Project Packages Module"""
+
+import abc
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import requirements
+
+from micropy import utils
+from micropy.exceptions import StubError
+from micropy.logger import Log
+from micropy.project.template import TemplateProvider
+
+from . import ProjectModule
+
+
+class PackagesModule(ProjectModule):
+
+    def __init__(self, path, name=None, packages=None, *args, **kwargs):
+        self._path = Path(path)
+        self._loaded = False
+        packages = packages or {}
+        self.name = name or "packages"
+        self.packages = {**packages}
+
+    @property
+    def path(self):
+        path = self.parent.path / self._path
+        return path
+
+    @property
+    def config(self):
+        return {
+            self.name: self.packages
+        }
+
+    def _fetch_package(self, url):
+        """Fetch and stub package at url
+
+        Args:
+            url (str): URL to fetch
+
+        Returns:
+            Path: path to package
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            file_name = utils.get_url_filename(url)
+            _file_name = "".join(self.log.iter_formatted(f"$B[{file_name}]"))
+            content = utils.stream_download(
+                url, desc=f"{self.log.get_service()} {_file_name}")
+            pkg_path = utils.extract_tarbytes(content, tmp_path)
+            ignore = ['setup.py', '__version__', 'test_']
+            pkg_init = next(pkg_path.rglob("__init__.py"), None)
+            py_files = [f for f in pkg_path.rglob(
+                "*.py") if not any(i in f.name for i in ignore)]
+            stubs = [utils.generate_stub(f) for f in py_files]
+            if pkg_init:
+                data_path = self.parent.pkg_data / pkg_init.parent.name
+                shutil.copytree(pkg_init.parent, data_path)
+                return data_path
+            for file, stub in stubs:
+                shutil.copy2(file, (self.parent.pkg_data / file.name))
+                shutil.copy2(stub, (self.parent.pkg_data / stub.name))
+
+    def load(self):
+        """Retrieves and stubs project requirements"""
+        self.parent.pkg_data.mkdir(exist_ok=True)
+        pkg_keys = set(self.packages.keys())
+        pkg_cache = self.parent._get_cache('pkg_loaded')
+        new_pkgs = pkg_keys.copy()
+        if pkg_cache:
+            new_pkgs = new_pkgs - set(pkg_cache)
+        pkgs = [(name, s)
+                for name, s in self.packages.items() if name in new_pkgs]
+        if pkgs and not self._loaded:
+            self.log.title("Fetching Requirements")
+        for name, spec in pkgs:
+            meta = utils.get_package_meta(name, spec=spec)
+            tar_url = meta['url']
+            self._fetch_package(tar_url)
+        self.update()
+        self.parent._set_cache('pkg_loaded', list(pkg_keys))
+
+    def create(self):
+        pass
+
+    def update(self):
+        """Dumps packages to file at path"""
+        if not self.path.exists():
+            self.path.touch()
+        pkgs = [(f"{name}{spec}" if spec and spec != "*" else name)
+                for name, spec in self.packages.items()]
+        with self.path.open('r+') as f:
+            content = [c.strip() for c in f.readlines() if c.strip() != '']
+            _lines = sorted(set(pkgs) | set(content))
+            lines = [l + "\n" for l in _lines]
+            f.seek(0)
+            f.writelines(lines)

--- a/micropy/project/modules/packages.py
+++ b/micropy/project/modules/packages.py
@@ -2,20 +2,14 @@
 
 """Project Packages Module"""
 
-import abc
-import json
 import shutil
-import sys
 import tempfile
 from pathlib import Path
 
 import requirements
 
 from micropy import utils
-from micropy.exceptions import StubError
-from micropy.logger import Log
 from micropy.project.modules import ProjectModule
-from micropy.project.template import TemplateProvider
 
 
 class PackagesModule(ProjectModule):

--- a/micropy/project/modules/packages.py
+++ b/micropy/project/modules/packages.py
@@ -56,6 +56,7 @@ class PackagesModule(ProjectModule):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             file_name = utils.get_url_filename(url)
+            self.log.debug(f"Fetching package: {file_name}")
             _file_name = "".join(self.log.iter_formatted(f"$B[{file_name}]"))
             content = utils.stream_download(
                 url, desc=f"{self.log.get_service()} {_file_name}")
@@ -67,11 +68,25 @@ class PackagesModule(ProjectModule):
             stubs = [utils.generate_stub(f) for f in py_files]
             if pkg_init:
                 data_path = self.pkg_path / pkg_init.parent.name
+                shutil.rmtree(data_path, ignore_errors=True)
                 shutil.copytree(pkg_init.parent, data_path)
                 return data_path
-            for file, stub in stubs:
-                shutil.copy2(file, (self.pkg_path / file.name))
-                shutil.copy2(stub, (self.pkg_path / stub.name))
+            # Iterates over flattened list of stubs tuple
+            file_paths = [(f, (self.pkg_path / f.name)) for f in list(sum(stubs, ()))]
+            for paths in file_paths:
+                shutil.move(*paths)  # overwrite if existing
+
+    @ProjectModule.hook(dev=False)
+    def add_from_file(self, path=None, dev=False, **kwargs):
+        """Loads all requirements from file
+
+        Args:
+            path (str): Path to file. Defaults to self.path.
+        """
+        reqs = utils.iter_requirements(self.path)
+        for req in reqs:
+            self.add_package(req, fetch=True)
+        return reqs
 
     @ProjectModule.hook()
     def add_package(self, package, dev=False, **kwargs):
@@ -79,15 +94,16 @@ class PackagesModule(ProjectModule):
 
         Args:
             package (str): package name/spec
-            dev (bool, optional): Flag requirement as dev. Defaults to False.
 
         Returns:
             dict: Dictionary of packages
         """
-        pkg = next(requirements.parse(package))
+        pkg = package
+        if isinstance(package, str):
+            pkg = next(requirements.parse(package))
         self.log.info(f"Adding $[{pkg.name}] to requirements...")
         if self.packages.get(pkg.name, None):
-            self.log.error(f"$[{package}] is already installed!")
+            self.log.error(f"$[{pkg.name}] is already installed!")
             return None
         specs = "".join(next(iter(pkg.specs))) if pkg.specs else "*"
         self.packages[pkg.name] = specs
@@ -99,25 +115,30 @@ class PackagesModule(ProjectModule):
     def load(self, fetch=True, **kwargs):
         """Retrieves and stubs project requirements"""
         self.pkg_path.mkdir(exist_ok=True)
+        if self.path.exists():
+            packages = utils.iter_requirements(self.path)
+            for p in packages:
+                spec = "".join(next(iter(p.specs))) if p.specs else "*"
+                self.packages.update({p.name: spec})
         pkg_keys = set(self.packages.keys())
-        pkg_cache = self.parent._get_cache('pkg_loaded')
+        pkg_cache = self.parent._get_cache(self.name)
         new_pkgs = pkg_keys.copy()
         if pkg_cache:
             new_pkgs = new_pkgs - set(pkg_cache)
         pkgs = [(name, s)
                 for name, s in self.packages.items() if name in new_pkgs]
         if fetch:
-            if pkgs and not self._loaded:
+            if pkgs:
                 self.log.title("Fetching Requirements")
             for name, spec in pkgs:
                 meta = utils.get_package_meta(name, spec=spec)
                 tar_url = meta['url']
                 self._fetch_package(tar_url)
         self.update()
-        self.parent._set_cache('pkg_loaded', list(pkg_keys))
+        self.parent._set_cache(self.name, list(pkg_keys))
 
     def create(self):
-        pass
+        return self.update()
 
     def update(self):
         """Dumps packages to file at path"""
@@ -146,3 +167,7 @@ class DevPackagesModule(PackagesModule):
     @ProjectModule.hook(dev=True)
     def add_package(self, package, **kwargs):
         return super().add_package(package, **kwargs)
+
+    @ProjectModule.hook(dev=True)
+    def add_from_file(self, path=None, **kwargs):
+        return super().add_from_file(path=path, **kwargs)

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -20,16 +20,16 @@ class StubsModule(ProjectModule):
     def context(self):
         """Get project template context"""
         paths = []
+        _paths = self.parent._context.get('paths', [])
         if self.stubs:
             frozen = [s.frozen for s in self.stubs]
             fware_mods = [s.firmware.frozen
                           for s in self.stubs if s.firmware is not None]
             stub_paths = [s.stubs for s in self.stubs]
-            paths = [*fware_mods, *frozen, *stub_paths]
-            if self.parent.pkg_data.exists():
-                paths.append(self.parent.pkg_data)
+            paths = set([*fware_mods, *frozen, *stub_paths])
+        paths = list(paths.union(_paths))
         return {
-            "stubs": self.stubs,
+            "stubs": set(self.stubs),
             "paths": paths,
             "datadir": self.parent.data_path,
         }

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -5,6 +5,7 @@
 import sys
 from pathlib import Path
 
+from micropy import utils
 from micropy.exceptions import StubError
 from micropy.project.modules import ProjectModule
 
@@ -13,7 +14,7 @@ class StubsModule(ProjectModule):
 
     def __init__(self, stub_manager, stubs=None):
         self.stub_manager = stub_manager
-        self.stubs = stubs
+        self._stubs = stubs
 
     @property
     def context(self):
@@ -39,6 +40,10 @@ class StubsModule(ProjectModule):
         return {
             'stubs': stubs
         }
+
+    @utils.lazy_property
+    def stubs(self):
+        return self._resolve_subresource(self._stubs)
 
     def _resolve_subresource(self, stubs):
         """Resolves stub resource
@@ -73,7 +78,6 @@ class StubsModule(ProjectModule):
                 yield self.stub_manager.add(name)
 
     def create(self):
-        self.stubs = self._resolve_subresource(self.stubs)
         self.log.info(
             f"Stubs: $[{' '.join(str(s) for s in self.stubs)}]")
         return self.stubs

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -41,7 +41,7 @@ class StubsModule(ProjectModule):
         }
 
     @property
-    @ProjectModule.hook
+    @ProjectModule.hook()
     def stubs(self):
         return self._resolve_subresource(self._stubs)
 
@@ -89,10 +89,13 @@ class StubsModule(ProjectModule):
         Args:
             stub_list (dict): Dict of Stubs
         """
+        self.log.title(f"Looking for Stubs...")
         stub_data = self.parent.data.get('stubs', {})
         stubs = list(self._load_stub_data(stub_data=stub_data))
         stubs.extend(self.stubs)
         self.stubs = self._resolve_subresource(stubs)
+        for stub in self.stubs:
+            self.log.info(f"Found => $[{stub}]")
         return self.stubs
 
     def create(self):
@@ -104,7 +107,7 @@ class StubsModule(ProjectModule):
         self.stubs = self.load()
         return self.stubs
 
-    @ProjectModule.hook
+    @ProjectModule.hook()
     def add_stub(self, stub, **kwargs):
         """Add stub to project
 

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+"""Project Stubs Module"""
+
+import abc
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import requirements
+
+from micropy import utils
+from micropy.exceptions import StubError
+from micropy.logger import Log
+from micropy.project.modules import ProjectModule
+from micropy.project.template import TemplateProvider
+
+
+class StubsModule(ProjectModule):
+
+    def __init__(self, stubs, stub_manager):
+        self.stub_manager = stub_manager
+        self.stubs = stubs
+
+    @property
+    def context(self):
+        """Get project template context"""
+        paths = []
+        if self.stubs:
+            frozen = [s.frozen for s in self.stubs]
+            fware_mods = [s.firmware.frozen
+                          for s in self.stubs if s.firmware is not None]
+            stub_paths = [s.stubs for s in self.stubs]
+            paths = [*fware_mods, *frozen, *stub_paths]
+            if self.parent.pkg_data.exists():
+                paths.append(self.parent.pkg_data)
+        return {
+            "stubs": self.stubs,
+            "paths": paths,
+            "datadir": self.parent.data_path,
+        }
+
+    @property
+    def config(self):
+        stubs = {s.name: s.stub_version for s in self.stubs}
+        return {
+            'stubs': stubs
+        }
+
+    def _resolve_subresource(self, stubs):
+        """Resolves stub resource
+
+        Args:
+            stubs (stubs): Stubs Passed to Manager
+        """
+        try:
+            resource = set(
+                self.stub_manager.resolve_subresource(stubs,
+                                                      self.parent.data_path))
+        except OSError as e:
+            msg = "Failed to Create Stub Links!"
+            exc = StubError(message=msg)
+            self.log.error(str(e), exception=exc)
+            sys.exit(1)
+        else:
+            return resource
+
+    def load(self, stubs=None):
+        """Loads stubs from info file
+
+        Args:
+            stub_list (dict): Dict of Stubs
+        """
+        stubs = stubs or self.data.get('stubs', self.stubs)
+        for name, location in stubs.items():
+            _path = self.path / location
+            if Path(_path).exists():
+                yield self.stub_manager.add(_path)
+            else:
+                yield self.stub_manager.add(name)
+
+    def create(self):
+        self.stubs = self._resolve_subresource(self.stubs)
+        self.log.info(
+            f"Stubs: $[{' '.join(str(s) for s in self.stubs)}]")
+        return self.stubs
+
+    def update(self):
+        pass
+
+    def add_stub(self, stub, **kwargs):
+        """Add stub to project
+
+        Args:
+            stub (Stub): Stub object to add
+
+        Returns:
+            [Stubs]: Project Stubs
+        """
+        loaded = self.stubs or []
+        stubs = [*loaded, stub]
+        self.log.info("Loading project...")
+        self.load(stubs=stubs)
+        self.log.info("Updating Project Info...")
+        self.parent.to_json()
+        self.log.info(
+            f"Project Stubs: $[{' '.join(str(s) for s in self.stubs)}]")
+        self.log.success("\nProject Updated!")
+        return self.stubs

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -2,20 +2,11 @@
 
 """Project Stubs Module"""
 
-import abc
-import json
-import shutil
 import sys
-import tempfile
 from pathlib import Path
 
-import requirements
-
-from micropy import utils
 from micropy.exceptions import StubError
-from micropy.logger import Log
 from micropy.project.modules import ProjectModule
-from micropy.project.template import TemplateProvider
 
 
 class StubsModule(ProjectModule):

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -20,7 +20,7 @@ from micropy.project.template import TemplateProvider
 
 class StubsModule(ProjectModule):
 
-    def __init__(self, stubs, stub_manager):
+    def __init__(self, stub_manager, stubs=None):
         self.stub_manager = stub_manager
         self.stubs = stubs
 

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -5,7 +5,6 @@
 import sys
 from pathlib import Path
 
-from micropy import utils
 from micropy.exceptions import StubError
 from micropy.project.modules import ProjectModule
 
@@ -41,7 +40,8 @@ class StubsModule(ProjectModule):
             'stubs': stubs
         }
 
-    @utils.lazy_property
+    @property
+    @ProjectModule.hook
     def stubs(self):
         return self._resolve_subresource(self._stubs)
 
@@ -55,6 +55,8 @@ class StubsModule(ProjectModule):
         Args:
             stubs (stubs): Stubs Passed to Manager
         """
+        if not hasattr(self, "_parent"):
+            return self._stubs
         try:
             resource = set(
                 self.stub_manager.resolve_subresource(stubs,
@@ -102,7 +104,7 @@ class StubsModule(ProjectModule):
         self.stubs = self.load()
         return self.stubs
 
-    @ProjectModule.method_hook
+    @ProjectModule.hook
     def add_stub(self, stub, **kwargs):
         """Add stub to project
 

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -85,6 +85,7 @@ class StubsModule(ProjectModule):
     def update(self):
         pass
 
+    @ProjectModule.method_hook
     def add_stub(self, stub, **kwargs):
         """Add stub to project
 
@@ -97,7 +98,7 @@ class StubsModule(ProjectModule):
         loaded = self.stubs or []
         stubs = [*loaded, stub]
         self.log.info("Loading project...")
-        self.load(stubs=stubs)
+        self.stubs = self._resolve_subresource(stubs)
         self.log.info("Updating Project Info...")
         self.parent.to_json()
         self.log.info(

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -63,13 +63,13 @@ class StubsModule(ProjectModule):
         else:
             return resource
 
-    def load(self, stubs=None):
+    def load(self, **kwargs):
         """Loads stubs from info file
 
         Args:
             stub_list (dict): Dict of Stubs
         """
-        stubs = stubs or self.data.get('stubs', self.stubs)
+        stubs = kwargs.get('stubs', self.data.get('stubs', self.stubs))
         for name, location in stubs.items():
             _path = self.path / location
             if Path(_path).exists():

--- a/micropy/project/modules/templates.py
+++ b/micropy/project/modules/templates.py
@@ -2,17 +2,7 @@
 
 """Project Templates Module"""
 
-import abc
-import json
-import shutil
-import sys
-import tempfile
-from pathlib import Path
 
-import requirements
-
-from micropy import utils
-from micropy.exceptions import StubError
 from micropy.logger import Log
 from micropy.project.modules import ProjectModule
 from micropy.project.template import TemplateProvider

--- a/micropy/project/modules/templates.py
+++ b/micropy/project/modules/templates.py
@@ -34,8 +34,12 @@ class TemplatesModule(ProjectModule):
         }
 
     def load(self, **kwargs):
-        templates = [k for k, v in self.parent.config['config'].items() if v]
+        _data = self.parent.data.get('config', {})
+        self.enabled = {**self.enabled, **_data}
+        templates = [k for k, v in self.enabled.items() if v]
+        self.log.debug(f"Loading Templates: {templates}")
         self.provider = TemplateProvider(templates, **kwargs)
+        self.update()
 
     def create(self):
         self.log.title("Rendering Templates")

--- a/micropy/project/modules/templates.py
+++ b/micropy/project/modules/templates.py
@@ -34,7 +34,7 @@ class TemplatesModule(ProjectModule):
         }
 
     def load(self, **kwargs):
-        templates = [k for k, v in self.parent.config.items() if v]
+        templates = [k for k, v in self.parent.config['config'].items() if v]
         self.provider = TemplateProvider(templates, **kwargs)
 
     def create(self):

--- a/micropy/project/modules/templates.py
+++ b/micropy/project/modules/templates.py
@@ -11,8 +11,9 @@ from micropy.project.template import TemplateProvider
 class TemplatesModule(ProjectModule):
     TEMPLATES = TemplateProvider.TEMPLATES
 
-    def __init__(self, templates=None, **kwargs):
+    def __init__(self, templates=None, run_checks=True, **kwargs):
         self.templates = templates or []
+        self.run_checks = run_checks
         self.enabled = {
             'vscode': False,
             'pylint': False
@@ -23,7 +24,8 @@ class TemplatesModule(ProjectModule):
             for key in self.enabled:
                 if key in self.templates:
                     self.enabled[key] = True
-            self.provider = TemplateProvider(templates, log=self.log, **kwargs)
+            self.provider = TemplateProvider(
+                templates, run_checks=self.run_checks, log=self.log, **kwargs)
 
     @property
     def config(self):

--- a/micropy/project/modules/templates.py
+++ b/micropy/project/modules/templates.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+"""Project Templates Module"""
+
+import abc
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import requirements
+
+from micropy import utils
+from micropy.exceptions import StubError
+from micropy.logger import Log
+from micropy.project.modules import ProjectModule
+from micropy.project.template import TemplateProvider
+
+
+class TemplatesModule(ProjectModule):
+
+    def __init__(self, templates, **kwargs):
+        self.templates = templates
+        self.enabled = {
+            'vscode': False,
+            'pylint': False
+        }
+        self.log = Log.add_logger(
+            'Templater', show_title=False)
+        for key in self.enabled:
+            if key in templates:
+                self.enabled[key] = True
+        self.provider = TemplateProvider(templates, log=self.log, **kwargs)
+
+    @property
+    def config(self):
+        return {
+            'config': self.enabled
+        }
+
+    def load(self, **kwargs):
+        templates = [k for k, v in self.parent.config.items() if v]
+        self.provider = TemplateProvider(templates, **kwargs)
+
+    def create(self):
+        self.log.title("Rendering Templates")
+        self.log.info("Populating Stub Info...")
+        for t in self.provider.templates:
+            self.provider.render_to(t, self.parent.path, **self.parent.context)
+        self.log.success("Stubs Injected!")
+        return self.parent.context
+
+    def update(self):
+        for tmp in self.provider.templates:
+            self.provider.update(tmp, self.parent.path, **self.parent.context)
+        return self.parent.context

--- a/micropy/project/modules/templates.py
+++ b/micropy/project/modules/templates.py
@@ -19,19 +19,21 @@ from micropy.project.template import TemplateProvider
 
 
 class TemplatesModule(ProjectModule):
+    TEMPLATES = TemplateProvider.TEMPLATES
 
-    def __init__(self, templates, **kwargs):
-        self.templates = templates
+    def __init__(self, templates=None, **kwargs):
+        self.templates = templates or []
         self.enabled = {
             'vscode': False,
             'pylint': False
         }
         self.log = Log.add_logger(
             'Templater', show_title=False)
-        for key in self.enabled:
-            if key in templates:
-                self.enabled[key] = True
-        self.provider = TemplateProvider(templates, log=self.log, **kwargs)
+        if templates:
+            for key in self.enabled:
+                if key in self.templates:
+                    self.enabled[key] = True
+            self.provider = TemplateProvider(templates, log=self.log, **kwargs)
 
     @property
     def config(self):

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -15,9 +15,10 @@ class Project(ProjectModule):
         self._children = []
         self.path = Path(path).absolute()
         self.data_path = self.path / '.micropy'
-        self.info_path = self.data_path / 'micropy.json'
+        self.info_path = self.path / 'micropy.json'
         self.cache_path = self.data_path / '.cache'
         self._context = {}
+        self._config = {}
 
         self.name = name or self.path.name
         self.log = Log.add_logger(self.name, show_title=False)
@@ -39,12 +40,17 @@ class Project(ProjectModule):
 
     @property
     def config(self):
-        _config = {
+        self._config = {
             'name': self.name
         }
         for child in self._children:
-            _config = {**_config, **child.config}
-        return _config
+            self._config = {**self._config, **child.config}
+        return self._config
+
+    @config.setter
+    def config(self, value):
+        self._config = value
+        return self._config
 
     @property
     def context(self):

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -2,24 +2,14 @@
 
 """Hosts functionality relating to generation of user projects."""
 
-import abc
 import json
-import shutil
-import sys
-import tempfile
 from pathlib import Path
 
-import requirements
-
-from micropy import utils
-from micropy.exceptions import StubError
 from micropy.logger import Log
-from micropy.project.template import TemplateProvider
-
-from . import modules
+from micropy.project.modules import ProjectModule
 
 
-class Project(modules.ProjectModule):
+class Project(ProjectModule):
 
     def __init__(self, path, name=None, **kwargs):
         self._children = []

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -2,6 +2,7 @@
 
 """Hosts functionality relating to generation of user projects."""
 
+import abc
 import json
 import shutil
 import sys
@@ -15,51 +16,53 @@ from micropy.exceptions import StubError
 from micropy.logger import Log
 from micropy.project.template import TemplateProvider
 
+from . import modules
 
-class Project:
-    """Handles Micropy Projects
 
-    Args:
-        path (str): Path to project
-        name (str, optional): Name of project.
-            Defaults to None. If none, path name is used.
-        stubs (Stub, optional): List of Stubs to use.
-            Defaults to None.
-        stub_manager (StubManager, optional): StubManager to source stubs.
-                Defaults to None.
-    """
+class Project(modules.ProjectModule):
 
-    TEMPLATES = TemplateProvider.TEMPLATES
-
-    def __init__(self, path, name=None, templates=[], stubs=None,
-                 stub_manager=None, **kwargs):
-        self._loaded = False
+    def __init__(self, path, name=None, **kwargs):
+        self._children = []
         self.path = Path(path).absolute()
-        self.data = self.path / '.micropy'
-        self.cache = self.data / '.cache'
-        self.info_path = self.path / 'micropy.json'
-        self.stub_manager = stub_manager
+        self.data_path = self.path / '.micropy'
+        self.info_path = self.data_path / 'micropy.json'
+        self.cache_path = self.data_path / '.cache'
 
         self.name = name or self.path.name
-        self.stubs = stubs
-
-        self.requirements = self.path / 'requirements.txt'
-        self.dev_requirements = self.path / 'dev-requirements.txt'
-        self.packages = {}
-        self.dev_packages = {'micropy-cli': '*'}
-        self.pkg_data = self.data / self.name
-
-        self.config = {'vscode': False, 'pylint': False}
         self.log = Log.add_logger(self.name, show_title=False)
-        template_log = Log.add_logger(
-            "Templater", parent=self.log, show_title=False)
-        self.provider = None
-        if templates:
-            for key in self.config:
-                if key in templates:
-                    self.config[key] = True
-            self.provider = TemplateProvider(
-                templates, log=template_log, **kwargs)
+        self.pkg_data = self.data_path / self.name
+
+    @property
+    def exists(self):
+        """Whether this project exists
+
+        Returns:
+            bool: True if it exists
+        """
+        return self.info_path.exists()
+
+    @property
+    def data(self):
+        if self.exists:
+            return json.loads(self.info_path.read_text())
+        return {}
+
+    @property
+    def config(self):
+        _config = {
+            'name': self.name
+        }
+        for child in self._children:
+            _config = {**_config, **child.config}
+        return _config
+
+    @property
+    def context(self):
+        _context = {}
+        for child in self._children:
+            child_context = getattr(child, 'context', {})
+            _context = {**_context, **child_context}
+        return _context
 
     def _set_cache(self, key, value):
         """Set key in Project cache
@@ -68,11 +71,11 @@ class Project:
             key (str): Key to set
             value (obj): Value to set
         """
-        if not self.cache.exists():
-            self.cache.write_text("{}")
-        data = json.loads(self.cache.read_text())
+        if not self.cache_path.exists():
+            self.cache_path.write_text("{}")
+        data = json.loads(self.cache_path.read_text())
         data[key] = value
-        with self.cache.open('w+') as f:
+        with self.cache_path.open('w+') as f:
             json.dump(data, f)
 
     def _get_cache(self, key):
@@ -84,251 +87,20 @@ class Project:
         Returns:
             obj: Value at key
         """
-        if not self.cache.exists():
+        if not self.cache_path.exists():
             return None
-        data = json.loads(self.cache.read_text())
+        data = json.loads(self.cache_path.read_text())
         value = data.pop(key, None)
         return value
 
-    def _resolve_subresource(self, stubs):
-        """Resolves stub resource
+    def add(self, component):
+        self._children.append(component)
+        component.parent = self
+        component.log = self.log
 
-        Args:
-            stubs (stubs): Stubs Passed to Manager
-        """
-        try:
-            resource = set(
-                self.stub_manager.resolve_subresource(stubs, self.data))
-        except OSError as e:
-            msg = "Failed to Create Stub Links!"
-            exc = StubError(message=msg)
-            self.log.error(str(e), exception=exc)
-            sys.exit(1)
-        else:
-            return resource
-
-    def _load_stubs(self, stubs):
-        """Loads stubs from info file
-
-        Args:
-            stub_list (dict): Dict of Stubs
-        """
-        for name, location in stubs.items():
-            _path = self.path / location
-            if Path(_path).exists():
-                yield self.stub_manager.add(_path)
-            else:
-                yield self.stub_manager.add(name)
-
-    def _fetch_package(self, url):
-        """Fetch and stub package at url
-
-        Args:
-            url (str): URL to fetch
-
-        Returns:
-            Path: path to package
-        """
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            file_name = utils.get_url_filename(url)
-            _file_name = "".join(self.log.iter_formatted(f"$B[{file_name}]"))
-            content = utils.stream_download(
-                url, desc=f"{self.log.get_service()} {_file_name}")
-            pkg_path = utils.extract_tarbytes(content, tmp_path)
-            ignore = ['setup.py', '__version__', 'test_']
-            pkg_init = next(pkg_path.rglob("__init__.py"), None)
-            py_files = [f for f in pkg_path.rglob(
-                "*.py") if not any(i in f.name for i in ignore)]
-            stubs = [utils.generate_stub(f) for f in py_files]
-            if pkg_init:
-                data_path = self.pkg_data / pkg_init.parent.name
-                shutil.copytree(pkg_init.parent, data_path)
-                return data_path
-            for file, stub in stubs:
-                shutil.copy2(file, (self.pkg_data / file.name))
-                shutil.copy2(stub, (self.pkg_data / stub.name))
-
-    def load_packages(self):
-        """Retrieves and stubs project requirements"""
-        pkg_keys = set(self.packages.keys())
-        pkg_cache = self._get_cache('pkg_loaded')
-        new_pkgs = pkg_keys.copy()
-        if pkg_cache:
-            new_pkgs = new_pkgs - set(pkg_cache)
-        pkgs = [(name, s)
-                for name, s in self.packages.items() if name in new_pkgs]
-        if pkgs and not self._loaded:
-            self.log.title("Fetching Requirements")
-        for name, spec in pkgs:
-            meta = utils.get_package_meta(name, spec=spec)
-            tar_url = meta['url']
-            self._fetch_package(tar_url)
-        self.update_all()
-        self._set_cache('pkg_loaded', list(pkg_keys))
-
-    def load(self, verbose=True, **kwargs):
-        """Load existing project
-
-        Args:
-            verbose (bool): Log to stdout. Defaults to True.
-
-        Returns:
-            stubs: Project Stubs
-        """
-        data = json.loads(self.info_path.read_text())
-        _stubs = data.get("stubs")
-        self.name = data.get("name", self.name)
-        self.config = data.get("config", self.config)
-        templates = [k for k, v in self.config.items() if v]
-        self.provider = TemplateProvider(templates, **kwargs)
-        self.packages = data.get("packages", self.packages)
-        self.dev_packages = data.get("dev-packages", self.dev_packages)
-        self.stubs = kwargs.get('stubs', self.stubs)
-        self.stub_manager = kwargs.get("stub_manager", self.stub_manager)
-        self.stub_manager.verbose_log(verbose)
-        self.data.mkdir(exist_ok=True)
-        stubs = list(self._load_stubs(_stubs))
-        if self.stubs:
-            stubs.extend(self.stubs)
-        self.stubs = self._resolve_subresource(stubs)
-        self.pkg_data.mkdir(exist_ok=True)
-        self.load_packages()
-        self._loaded = True
-        if verbose:
-            self.log.success(f"\nProject Ready!")
-        return self.stubs
-
-    def add_stub(self, stub, **kwargs):
-        """Add stub to project
-
-        Args:
-            stub (Stub): Stub object to add
-
-        Returns:
-            [Stubs]: Project Stubs
-        """
-        loaded = self.stubs or []
-        stubs = [*loaded, stub]
-        self.log.info("Loading project...")
-        self.load(stubs=stubs, verbose=False, **kwargs)
-        self.log.info("Updating Project Info...")
-        self.to_json()
-        self.log.info(
-            f"Project Stubs: $[{' '.join(str(s) for s in self.stubs)}]")
-        self.log.success("\nProject Updated!")
-        return self.stubs
-
-    def add_package(self, package, dev=False):
-        """Add requirement to project
-
-        Args:
-            package (str): package name/spec
-            dev (bool, optional): Flag requirement as dev. Defaults to False.
-
-        Returns:
-            dict: Dictionary of packages
-        """
-        pkg = next(requirements.parse(package))
-        self.log.info(f"Adding $[{pkg.name}] to requirements...")
-        packages = self.dev_packages if dev else self.packages
-        if packages.get(pkg.name, None):
-            self.log.error(f"$[{package}] is already installed!")
-            return None
-        specs = "".join(next(iter(pkg.specs))) if pkg.specs else "*"
-        packages[pkg.name] = specs
-        self.to_json()
-        self.load_packages()
-        self.log.success("Package installed!")
-        return packages
-
-    def _add_pkgs_from_file(self, path, **kwargs):
-        """Add packages listed in a file
-
-        Args:
-            path (str): path to file
-
-        Returns:
-            list of added reqs
-        """
-        if not path.exists():
-            return []
-        reqs = list(utils.iter_requirements(path))
-        for req in reqs:
-            self.add_package(req.line, **kwargs)
-        return reqs
-
-    def add_from_requirements(self):
-        """Add all packages in requirements.txt files
-
-        Returns:
-            List of all added requirements
-        """
-        reqs = self._add_pkgs_from_file(self.requirements)
-        dev_reqs = self._add_pkgs_from_file(self.dev_requirements, dev=True)
-        all_reqs = [*reqs, *dev_reqs]
-        return all_reqs if all_reqs else None
-
-    def exists(self):
-        """Whether this project exists
-
-        Returns:
-            bool: True if it exists
-        """
-        return self.info_path.exists()
-
-    @property
-    def context(self):
-        """Get project template context"""
-        paths = []
-        if self.stubs:
-            frozen = [s.frozen for s in self.stubs]
-            fware_mods = [s.firmware.frozen
-                          for s in self.stubs if s.firmware is not None]
-            stub_paths = [s.stubs for s in self.stubs]
-            paths = [*fware_mods, *frozen, *stub_paths]
-            if self.pkg_data.exists():
-                paths.append(self.pkg_data)
-        return {
-            "stubs": self.stubs,
-            "paths": paths,
-            "datadir": self.data,
-        }
-
-    @property
-    def info(self):
-        """Project Information"""
-        stubs = {s.name: s.stub_version for s in self.stubs}
-        return {
-            "name": self.name,
-            "stubs": stubs,
-            "config": self.config,
-            "packages": self.packages,
-            "dev-packages": self.dev_packages
-        }
-
-    def _dump_requirements(self, packages, path):
-        """Dumps packages to file at path
-
-        Args:
-            packages (dict): dict of packages to dump
-            path (str): path to fiel
-        """
-        if not path.exists():
-            path.touch()
-        pkgs = [(f"{name}{spec}" if spec and spec != "*" else name)
-                for name, spec in packages.items()]
-        with path.open('r+') as f:
-            content = [c.strip() for c in f.readlines() if c.strip() != '']
-            _lines = sorted(set(pkgs) | set(content))
-            lines = [l + "\n" for l in _lines]
-            f.seek(0)
-            f.writelines(lines)
-
-    def to_requirements(self):
-        """Dumps requirements to .txt files"""
-        self._dump_requirements(self.packages, self.requirements)
-        self._dump_requirements(self.dev_packages, self.dev_requirements)
+    def remove(self, component):
+        self._children.remove(component)
+        component.parent = None
 
     def to_json(self):
         """Dumps project to data file"""
@@ -336,33 +108,23 @@ class Project:
             data = json.dumps(self.info, indent=4)
             f.write(data)
 
-    def render_all(self):
-        """Renders all project files"""
-        self.log.info("Populating Stub info...")
-        for t in self.provider.templates:
-            self.provider.render_to(t, self.path, **self.context)
-        self.log.success("Stubs Injected!")
-        return self.context
-
-    def update_all(self):
-        """Updates all project files"""
-        self.to_requirements()
-        for t in self.provider.templates:
-            self.provider.update(t, self.path, **self.context)
-        return self.context
+    def load(self, **kwargs):
+        self.name = self.data.get("name", self.name)
+        self.config = self.data.get("config", self.config)
+        self.data_path.mkdir(exist_ok=True)
+        for child in self._children:
+            child.load(**kwargs)
+        return self
 
     def create(self):
-        """creates a new project"""
         self.log.title(f"Initiating $[{self.name}]")
-        self.data.mkdir(exist_ok=True, parents=True)
-        self.stubs = self._resolve_subresource(self.stubs)
-        self.log.info(
-            f"Stubs: $[{' '.join(str(s) for s in self.stubs)}]")
+        self.data_path.mkdir(exist_ok=True, parents=True)
         self.log.debug(f"Generated Project Context: {self.context}")
-        if self.provider:
-            self.log.title("Rendering Templates")
-            self.render_all()
-        self.update_all()
-        self.to_json()
-        self.log.success(f"Project Created!")
+        for child in self._children:
+            child.create()
         return self.path.relative_to(Path.cwd())
+
+    def update(self):
+        for child in self._children:
+            child.update()
+        return self

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -125,13 +125,3 @@ class Project(ProjectModule):
         for child in self._children:
             child.update()
         return self
-
-    def add_stub(self, *args, **kwargs):
-        for child in self._children:
-            if hasattr(child, 'add_stub'):
-                return child.add_stub(*args, **kwargs)
-
-    def add_package(self, *args, **kwargs):
-        for child in self._children:
-            if hasattr(child, 'add_package'):
-                return child.add_package(*args, **kwargs)

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -128,3 +128,13 @@ class Project(modules.ProjectModule):
         for child in self._children:
             child.update()
         return self
+
+    def add_stub(self, *args, **kwargs):
+        for child in self._children:
+            if hasattr(child, 'add_stub'):
+                return child.add_stub(*args, **kwargs)
+
+    def add_package(self, *args, **kwargs):
+        for child in self._children:
+            if hasattr(child, 'add_package'):
+                return child.add_package(*args, **kwargs)

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -24,9 +24,11 @@ class Project(ProjectModule):
         self.log = Log.add_logger(self.name, show_title=False)
 
     def __getattr__(self, name):
-        result = next(iter([c.resolve_hook(name) for c in self._children]), None)
-        if result is not None:
-            return result
+        results = iter([c.resolve_hook(name) for c in self._children])
+        for res in results:
+            if res is not None:
+                self.log.debug(f"Hook Resolved: {name} -> {res}")
+                return res
         return self.__getattribute__(name)
 
     @property

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -17,10 +17,10 @@ class Project(ProjectModule):
         self.data_path = self.path / '.micropy'
         self.info_path = self.data_path / 'micropy.json'
         self.cache_path = self.data_path / '.cache'
+        self._context = {}
 
         self.name = name or self.path.name
         self.log = Log.add_logger(self.name, show_title=False)
-        self.pkg_data = self.data_path / self.name
 
     @property
     def exists(self):
@@ -48,11 +48,10 @@ class Project(ProjectModule):
 
     @property
     def context(self):
-        _context = {}
         for child in self._children:
             child_context = getattr(child, 'context', {})
-            _context = {**_context, **child_context}
-        return _context
+            self._context = {**self._context, **child_context}
+        return self._context
 
     def _set_cache(self, key, value):
         """Set key in Project cache
@@ -95,7 +94,7 @@ class Project(ProjectModule):
     def to_json(self):
         """Dumps project to data file"""
         with self.info_path.open('w+') as f:
-            data = json.dumps(self.info, indent=4)
+            data = json.dumps(self.config, indent=4)
             f.write(data)
 
     def load(self, **kwargs):
@@ -112,6 +111,8 @@ class Project(ProjectModule):
         self.log.debug(f"Generated Project Context: {self.context}")
         for child in self._children:
             child.create()
+        self.to_json()
+        self.log.success(f"Project Created!")
         return self.path.relative_to(Path.cwd())
 
     def update(self):

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -23,6 +23,12 @@ class Project(ProjectModule):
         self.name = name or self.path.name
         self.log = Log.add_logger(self.name, show_title=False)
 
+    def __getattr__(self, name):
+        result = next(iter([c.resolve_hook(name) for c in self._children]), None)
+        if result is not None:
+            return result
+        return self.__getattribute__(name)
+
     @property
     def exists(self):
         """Whether this project exists

--- a/micropy/project/template.py
+++ b/micropy/project/template.py
@@ -150,12 +150,13 @@ class CodeTemplate(Template):
     @property
     def context(self):
         """VScode Config Context"""
+        paths = self.paths
         if self.datadir:
             paths = [str(p.relative_to(self.datadir.parent))
                      for p in self.paths]
         stub_paths = json.dumps(paths)
         ctx = {
-            "stubs": self.stubs,
+            "stubs": self.stubs or [],
             "paths": stub_paths,
         }
         return ctx
@@ -173,11 +174,12 @@ class PylintTemplate(Template):
     @property
     def context(self):
         """Pylint Config Context"""
+        paths = self.paths
         if self.datadir:
             paths = [p.relative_to(self.datadir.parent) for p in self.paths]
         ctx = {
-            "stubs": self.stubs,
-            "paths": paths
+            "stubs": self.stubs or [],
+            "paths": paths or []
         }
         return ctx
 

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -49,10 +49,11 @@ class StubManager:
             stubs ([Stub], optional): Sublist of Stubs to iterate over.
                 Defaults to None. If none, uses all installed stubs.
         """
+        loaded = stubs or self._loaded
         for firm in self._firmware:
-            stubs = [s for s in self._loaded if s.firmware == firm]
+            stubs = [s for s in loaded if s.firmware == firm]
             yield (firm, stubs)
-        other = [s for s in self._loaded if s.firmware is None]
+        other = [s for s in loaded if s.firmware is None]
         yield ("Unknown", other)
 
     def verbose_log(self, state):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ REQUIRED = [
     'tqdm',
     'requirements-parser',
     'packaging',
-    'cachier'
+    'cachier',
+    'boltons'
 ]
 
 EXTRAS = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,6 @@ def cleanup_data():
         micropy.stubs.source.StubRepo.repos = set()
     except Exception:
         importlib.reload(micropy)
-        pass
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,7 +162,7 @@ def test_cli_install(mocker, runner, mock_mpy):
     # Test from requirements
     result = runner.invoke(cli.install, "")
     assert result.exit_code == 0
-    mock_proj.add_from_requirements.return_value = None
+    mock_proj.add_from_file.return_value = None
     result = runner.invoke(cli.install, "")
     assert result.exit_code == 1
     # Test no project found

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,7 +106,7 @@ def test_cli_init(mocker, mock_mpy, shared_datadir, mock_prompt, runner, cliargs
     mock_modules.StubsModule.assert_called_once_with(mock_mpy.stubs, stubs=['stub'])
     # Assert Reqs
     mock_modules.PackagesModule.assert_any_call("requirements.txt")
-    mock_modules.PackagesModule.assert_any_call("dev-requirements.txt", dev=True)
+    mock_modules.DevPackagesModule.assert_any_call("dev-requirements.txt")
     # Assert Exit Code
     mock_project.return_value.create.assert_called_once()
     assert result.exit_code == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -91,6 +91,6 @@ def test_stub_error():
 def test_resolve_project(mocker, mock_micropy):
     mock_proj = mocker.patch.object(main, "Project").return_value
     mock_proj.exists = False
-    assert mock_micropy.resolve_project('.') is None
+    assert not mock_micropy.resolve_project('.').exists
     mock_proj.exists = True
     assert mock_micropy.resolve_project('.')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -90,7 +90,7 @@ def test_stub_error():
 
 def test_resolve_project(mocker, mock_micropy):
     mock_proj = mocker.patch.object(main, "Project").return_value
-    mock_proj.exists.return_value = False
+    mock_proj.exists = False
     assert mock_micropy.resolve_project('.') is None
-    mock_proj.exists.return_value = True
+    mock_proj.exists = True
     assert mock_micropy.resolve_project('.')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -42,7 +42,7 @@ def get_module():
             'template': partial(modules.TemplatesModule,
                                 templates=_templates),
             'reqs': partial(modules.PackagesModule, 'requirements.txt'),
-            'dev-reqs': partial(modules.PackagesModule, 'dev-requirements.txt', dev=True)
+            'dev-reqs': partial(modules.DevPackagesModule, 'dev-requirements.txt')
         }
         if names == 'all':
             names = ",".join(list(mods.keys()))
@@ -262,3 +262,9 @@ class TestPackagesModule:
         mock_rglob.return_value = iter([Path("SomePkg/__init__.py")])
         res = proj.add_package('anotha_pkg')
         mock_shutil.copytree.assert_called_once()
+
+    def test_add_dev_package(self, mocker, mock_pkg, test_project):
+        proj, mp = next(test_project('reqs,dev-reqs'))
+        proj.create()
+        proj.add_package('somepkg')
+        proj.add_package('anotha_pkg', dev=True)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,171 +1,50 @@
 # -*- coding: utf-8 -*-
 
-import shutil
+import pathlib
+from functools import partial
 from pathlib import Path
 
 import pytest
 
-from micropy import main, project
-from micropy.project.template import TemplateProvider
+from micropy import project
+from micropy.project import modules
+
+
+@pytest.fixture(autouse=True)
+def mock_requests(mocker):
+    mocker.patch('requests.session')
 
 
 @pytest.fixture
-def mock_pkg(mocker, tmp_path):
-    """return mock package"""
-    tmp_pkg = tmp_path / 'tmp_pkg'
-    tmp_pkg.mkdir()
-    mock_tarbytes = mocker.patch.object(
-        project.project.utils, 'extract_tarbytes')
-    mocker.patch.object(
-        project.project.utils, 'get_package_meta')
-    mocker.patch.object(
-        project.project.utils, 'get_url_filename')
-    mocker.patch.object(
-        project.project.utils, 'stream_download')
-    mock_tarbytes.return_value = tmp_pkg
-    return tmp_pkg
+def get_module(micropy_stubs):
+    mp = micropy_stubs()
+    mods = {
+        'stubs': partial(modules.StubsModule, mp.stubs, stubs=list(mp.stubs)[:1]),
+        'template': partial(modules.TemplatesModule,
+                            templates=list(modules.TemplatesModule.TEMPLATES.keys())),
+        'reqs': partial(modules.PackagesModule, 'requirements.txt'),
+        'dev-reqs': partial(modules.PackagesModule, 'dev-requirements.txt', name='dev-packages')
+    }
+
+    def _get_module(name, **kwargs):
+        if name == 'all':
+            _mods = [mods[n] for n in list(mods.keys())]
+            for m in _mods:
+                yield m
+        else:
+            mod = mods[name]
+            mod.keywords.update(**kwargs)
+            yield mod
+    return _get_module
 
 
-@pytest.fixture
-def mock_proj_dir(mocker, tmp_path, shared_datadir):
-    proj_path = tmp_path / 'tmp_project'
-    shutil.copytree((shared_datadir / 'project_test'), proj_path)
-    return proj_path
-
-
-def test_project_init(mock_mp_stubs, mock_cwd):
-    """Test project setup"""
-    mp = mock_mp_stubs
-    proj_stubs = list(mp.stubs)[:2]
-    proj_path = mock_cwd / "ProjName"
-    proj = project.Project(proj_path, stubs=proj_stubs)
-    assert proj.path == mock_cwd / 'ProjName'
-    assert proj.name == 'ProjName'
-
-
-def test_project_structure(mock_mp_stubs, mock_cwd, mock_checks):
-    """Test if project creates files"""
-    mp = mock_mp_stubs
-    proj_stubs = list(mp.stubs)[:2]
-    proj_path = mock_cwd / "ProjName"
-    templates = ['vscode', 'pylint', 'bootstrap', 'pymakr', 'gitignore']
-    proj = project.Project(proj_path, templates=templates, stubs=proj_stubs,
-                           stub_manager=mp.stubs)
-    proj.create()
-    templ_files = [i.name for i in (
-        TemplateProvider.TEMPLATE_DIR).glob("**/*")]
-    proj_files = sorted(
-        [i.name for i in proj.path.glob("**/*")])
-    expect_files = sorted([*templ_files, *[s.path.name for s in proj.stubs],
-                           *set([s.firmware.path.name for s in proj.stubs]),
-                           '.micropy', 'micropy.json', 'requirements.txt',
-                           'dev-requirements.txt'])
-    print("Project Files:", proj_files)
-    print("Expect:", expect_files)
-    assert expect_files == proj_files
-
-
-def test_project_load(mocker, shared_datadir, mock_pkg):
-    mock_mp = mocker.patch.object(main, 'MicroPy').return_value
-    mock_utils = mocker.patch.object(project.project, 'utils')
-    mock_shutil = mocker.patch.object(project.project, 'shutil')
-    mock_utils.extract_tarbytes.return_value.rglob.side_effect = [
-        iter([]),
-        iter([
-            Path("foobar.py"), Path("setup.py")]),
-        iter([
-            Path("pkg/__init__.py")]),
-        iter([
-            Path("foobar.py"), Path("setup.py")]),
-    ]
-    mock_utils.generate_stub.return_value = (Path(
-        "foobar.py"), Path("foobar.pyi"))
-    proj_path = shared_datadir / 'project_test'
-    proj = project.Project(proj_path, stub_manager=mock_mp.stubs)
-    proj.load()
-    expect_custom = proj.path / '../esp32_test_stub'
-    mock_mp.stubs.add.assert_any_call("esp32-micropython-1.11.0")
-    mock_mp.stubs.add.assert_any_call("esp8266-micropython-1.11.0")
-    mock_mp.stubs.add.assert_any_call(expect_custom)
-    assert mock_mp.stubs.add.call_count == 3
-    mock_mp.stubs.resolve_subresource.assert_called_once_with(
-        mocker.ANY, proj.data)
-    assert proj.data.exists()
-    assert mock_shutil.copy2.call_count == 2
-    mock_shutil.copy2.assert_called_with(
-        Path("foobar.pyi"), (proj.pkg_data / "foobar.pyi"))
-    # Test package
-    proj.add_package('pkg')
-    mock_shutil.copytree.assert_called_once_with(
-        Path('pkg'), (proj.pkg_data / 'pkg'))
-    # Test Win Priv Fail
-    mock_mp.stubs.resolve_subresource.side_effect = [OSError]
-    with pytest.raises(SystemExit):
-        proj = project.Project(proj_path, stub_manager=mock_mp.stubs)
-        proj.load()
-
-
-def test_project_add_stub(mocker, shared_datadir, tmp_path, mock_pkg):
-    """should add stub to project"""
-    m_stubman = mocker.MagicMock()
-    proj_path = tmp_path / 'tmp_project'
-    shutil.copytree((shared_datadir / 'project_test'), proj_path)
-    # Test Loaded
-    proj = project.Project(proj_path, stub_manager=m_stubman)
-    proj.load()
-    proj.add_stub("mock_stub")
-    m_stubman.resolve_subresource.assert_called_with(
-        [mocker.ANY, mocker.ANY, mocker.ANY, "mock_stub"], proj.data)
-    shutil.rmtree(proj_path)
-    shutil.copytree((shared_datadir / 'project_test'), proj_path)
-    # Test Not loaded
-    proj = project.Project(proj_path, stub_manager=m_stubman)
-    proj.add_stub("mock_stub")
-    m_stubman.resolve_subresource.assert_called_with(
-        [mocker.ANY, mocker.ANY, mocker.ANY, "mock_stub"], proj.data)
-    assert m_stubman.resolve_subresource.call_count == 3
-
-
-def test_project_add_pkg(mocker, mock_proj_dir, shared_datadir, tmp_path,
-                         mock_pkg):
-    """should add package to requirements"""
-    m_stubman = mocker.MagicMock()
-    proj = project.Project(mock_proj_dir, stub_manager=m_stubman)
-    proj.load()
-    proj.add_package('mock_pkg')
-    assert proj.packages['mock_pkg'] == "*"
-    assert proj.add_package('mock_pkg') is None
-    # Test dev
-    proj.add_package('another_pkg==1.0.0', dev=True)
-    assert proj.dev_packages['another_pkg'] == '==1.0.0'
-    # Test requirements.txt
-    lines = proj.requirements.read_text().splitlines()
-    assert "mock_pkg" in lines
-    # Test Context
-    expect_proj_stubs = mock_proj_dir / '.micropy' / "NewProject"
-    m_stubman.resolve_subresource.return_value = [mocker.MagicMock()]
-    mock_update = mocker.patch.object(
-        project.project.TemplateProvider, 'update')
-    proj = project.Project(
-        mock_proj_dir, stub_manager=m_stubman, name="NewProject")
-    proj.load()
-    assert expect_proj_stubs in proj.context['paths']
-    mock_update.assert_called_with('vscode', proj.path, **proj.context)
-
-
-def test_project_add_requirements(mocker, mock_proj_dir, mock_pkg):
-    """should add from requirements.txt"""
-    mocker.patch.object(main, "MicroPy").return_value
-    proj = project.Project(mock_proj_dir, stub_manager=mocker.MagicMock())
-    proj.load()
-    # Assert no reqs file
-    _reqspath = (proj.requirements, proj.dev_requirements)
-    proj.requirements = Path('foobar')
-    proj.dev_requirements = Path('foobar')
-    added = proj.add_from_requirements()
-    assert added is None
-    proj.requirements, proj.dev_requirements = _reqspath
-    tmp_reqs = proj.path / 'requirements.txt'
-    tmp_reqs.touch()
-    tmp_reqs.write_text("micropy-cli==1.0.0")
-    assert next(iter(proj.add_from_requirements())).name == 'micropy-cli'
+@pytest.mark.parametrize('mods', ['stubs', 'template', 'reqs', 'dev-reqs', 'all'])
+def test_create_project(mocker, mock_cwd, get_module, mods):
+    mods = list(get_module(mods))
+    proj_path = mock_cwd / 'NewProject'
+    proj = project.Project(proj_path)
+    for m in mods:
+        print(mods)
+        proj.add(m())
+    resp = proj.create()
+    assert str(resp) == "NewProject"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pathlib
+import shutil
 from functools import partial
 from pathlib import Path
 
@@ -16,35 +17,127 @@ def mock_requests(mocker):
 
 
 @pytest.fixture
-def get_module(micropy_stubs):
-    mp = micropy_stubs()
-    mods = {
-        'stubs': partial(modules.StubsModule, mp.stubs, stubs=list(mp.stubs)[:1]),
-        'template': partial(modules.TemplatesModule,
-                            templates=list(modules.TemplatesModule.TEMPLATES.keys())),
-        'reqs': partial(modules.PackagesModule, 'requirements.txt'),
-        'dev-reqs': partial(modules.PackagesModule, 'dev-requirements.txt', name='dev-packages')
-    }
-
-    def _get_module(name, **kwargs):
-        if name == 'all':
-            _mods = [mods[n] for n in list(mods.keys())]
-            for m in _mods:
-                yield m
-        else:
-            mod = mods[name]
-            mod.keywords.update(**kwargs)
-            yield mod
+def get_module():
+    def _get_module(names, mp, **kwargs):
+        _templates = list(modules.TemplatesModule.TEMPLATES.keys())
+        mods = {
+            'stubs': partial(modules.StubsModule, mp.stubs, stubs=list(mp.stubs)[:2]),
+            'template': partial(modules.TemplatesModule,
+                                templates=_templates),
+            'reqs': partial(modules.PackagesModule, 'requirements.txt'),
+            'dev-reqs': partial(modules.PackagesModule, 'dev-requirements.txt', dev=True)
+        }
+        if names == 'all':
+            names = ",".join(list(mods.keys()))
+        _mods = [mods[n.strip()] for n in names.split(',') if n]
+        for m in _mods:
+            yield m
     return _get_module
 
 
-@pytest.mark.parametrize('mods', ['stubs', 'template', 'reqs', 'dev-reqs', 'all'])
-def test_create_project(mocker, mock_cwd, get_module, mods):
-    mods = list(get_module(mods))
-    proj_path = mock_cwd / 'NewProject'
-    proj = project.Project(proj_path)
-    for m in mods:
-        print(mods)
-        proj.add(m())
-    resp = proj.create()
-    assert str(resp) == "NewProject"
+@pytest.fixture
+def get_config():
+    def _get_config(request, name="NewProject", stubs=None, templates=None, packages={}):
+        templates = templates or ['vscode', 'pylint']
+        stubs = stubs or []
+        _mods = {
+            'base': {
+                'name': name
+            },
+            'stubs': {
+                'stubs': {s.name: s.stub_version for s in stubs}
+            },
+            'template': {
+                'config': {t: (t in templates) for t in templates}
+            },
+            'reqs': {
+                'packages': packages.get('reqs', {})
+            },
+            'dev-reqs': {
+                'dev-packages': packages.get('dev-reqs', {'micropy-cli': '*'})
+            }
+        }
+        if request == 'all':
+            request = ",".join(list(_mods.keys()))
+        mods = request.split(',')
+        test_config = _mods['base'].copy()
+        for m in mods:
+            test_config = {**test_config, **_mods[m or 'base']}
+        return test_config
+    return _get_config
+
+
+@pytest.fixture
+def get_context():
+    def _get_context(request, stubs=None, pkg_path=None, data_dir=None):
+        stubs = stubs or []
+        _frozen = [s.frozen for s in stubs]
+        _fware = [s.firmware.frozen for s in stubs if s.firmware is not None]
+        _stub_paths = [s.stubs for s in stubs]
+        _paths = set([*_frozen, *_fware, *_stub_paths])
+        _context = {
+            'base': {},
+            'stubs': {
+                'stubs': set(stubs),
+                'paths': list(_paths),
+                'datadir': data_dir
+            },
+            'reqs': {
+                'paths': [pkg_path]
+            }
+        }
+        if request == 'all':
+            request = ",".join(list(_context.keys()))
+        mods = request.split(',')
+        if 'reqs' in mods and 'stubs' in mods:
+            _ctx = _context['stubs'].copy()
+            _ctx['paths'].extend(_context['reqs']['paths'])
+            return _ctx
+        context = {}
+        for m in mods:
+            context = {**context, **_context.get(m, {})}
+        return context
+    return _get_context
+
+
+@pytest.yield_fixture
+def test_project(micropy_stubs, mock_cwd, tmp_path, get_module):
+    def _test_project(mods=""):
+        mp = micropy_stubs()
+        proj_path = tmp_path / "NewProject"
+        proj = project.Project(proj_path)
+        mods = get_module(mods, mp)
+        for m in mods:
+            proj.add(m())
+        yield proj, mp
+        shutil.rmtree(proj_path)
+    return _test_project
+
+
+@pytest.mark.parametrize('mods', ['', 'stubs', 'template', 'reqs', 'dev-reqs', 'all'])
+class TestProject:
+
+    def test_create(self, test_project, mods):
+        test_proj, _ = next(test_project(mods))
+        resp = test_proj.create()
+        assert str(resp) == "NewProject"
+        assert test_proj.exists
+
+    def test_config(self, test_project, get_config,  mods):
+        test_proj, mp = next(test_project(mods))
+        expect_config = get_config(mods, stubs=list(mp.stubs)[:2])
+        assert test_proj.config == expect_config
+
+    def test_context(self, test_project, get_context, mods):
+        test_proj, mp = next(test_project(mods))
+        pkg_path = test_proj.data_path / test_proj.name
+        stubs = mp.stubs.resolve_subresource(list(mp.stubs), test_proj.data_path)
+        expect_context = get_context(mods, stubs=stubs, pkg_path=pkg_path,
+                                     data_dir=test_proj.data_path)
+        for k in expect_context.keys():
+            print("Context Key:", k)
+            try:
+                assert sorted(test_proj.context.get(k, [])) == sorted(
+                    expect_context.get(k, []))
+            except TypeError:
+                assert test_proj.context.get(k, []) == expect_context[k]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import pathlib
 import shutil
 from functools import partial
 from pathlib import Path
 
 import pytest
 
-from micropy import exceptions as exc
 from micropy import project
 from micropy.project import modules
 
@@ -215,6 +213,8 @@ class TestStubsModule:
         mocker.resetall()
         stub_module.stub_manager.resolve_subresource = mocker.MagicMock()
         stub_module.stub_manager.resolve_subresource.side_effect = [OSError]
+        assert stub_module._resolve_subresource([]) == stub_module._stubs
+        stub_module._parent = mocker.MagicMock()
         with pytest.raises(SystemExit):
             stub_module._resolve_subresource([])
 
@@ -239,6 +239,7 @@ class TestStubsModule:
         stub.stubs = stub_path / 'stubs'
         stub.firmware = stub
         proj.add_stub(stub)
+        print(proj.stubs)
 
 
 class TestPackagesModule:

--- a/tests/test_pyboardwrapper.py
+++ b/tests/test_pyboardwrapper.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 
 from micropy.utils import PyboardWrapper, pybwrapper
-
 from micropy.utils.pybwrapper import PyboardError
 
 


### PR DESCRIPTION
Complete restructure of `micropy.project` module. 

Following the composite pattern for re-implementation. This will make it significantly more modular and therefore much easier to extend. Also it doesn't hurt your eyes nearly as much :+1: 

Currently three modules have been split from the old project class: 
* `PackagesModule` - Project Dependencies
* `StubsModule` - Project Level Stub Management
* `TemplatesModule` - Project Templates/Config

The above 3 classes are found under `micropy.project.modules`

The new classes can each be instantiated individually and added to a `Project` container as leafs.
