### PR TITLE
feat(deps): Uniform Dependency API

### DIFF
--- a/docs/_autosummary/micropy.packages.rst
+++ b/docs/_autosummary/micropy.packages.rst
@@ -1,0 +1,24 @@
+micropy.packages
+================
+
+.. automodule:: micropy.packages
+
+
+
+   .. rubric:: Functions
+
+   .. autosummary::
+
+      create_dependency_source
+
+
+
+
+
+   .. rubric:: Classes
+
+   .. autosummary::
+
+      LocalDependencySource
+      Package
+      PackageDependencySource

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -14,3 +14,4 @@ API Reference
    micropy.utils
    micropy.config
    micropy.config.config_source
+   micropy.packages

--- a/micropy/packages/__init__.py
+++ b/micropy/packages/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+"""Packages Module."""
+
+from pathlib import Path
+from typing import Any, Union, Optional
+
+import requirements
+
+from .package import Package
+from .source_package import PackageDependencySource
+from .source_path import LocalDependencySource
+
+
+def create_dependency_source(
+        requirement: str,
+        name: Optional[str] = None,
+        **kwargs: Any) -> Union[LocalDependencySource, PackageDependencySource]:
+    req = next(requirements.parse(str(requirement)))
+    if req.local_file:
+        path = Path(req.path)
+        name = name or path.name
+        pkg = Package(name, req.specs)
+        source = LocalDependencySource(pkg, path)
+        return source
+    pkg = Package(req.name, req.specs)
+    return PackageDependencySource(pkg, **kwargs)
+
+
+__all__ = ["Package", "PackageDependencySource",
+           "LocalDependencySource", "create_dependency_source"]

--- a/micropy/packages/__init__.py
+++ b/micropy/packages/__init__.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 
-"""Packages Module."""
+"""Packages Module.
+
+Allows user to address different dependency types (package, module, path,
+pypi, etc.) through a single uniform api.
+
+"""
 
 from pathlib import Path
-from typing import Any, Union, Optional
+from typing import Any, Optional, Union
 
 import requirements
 
@@ -16,6 +21,17 @@ def create_dependency_source(
         requirement: str,
         name: Optional[str] = None,
         **kwargs: Any) -> Union[LocalDependencySource, PackageDependencySource]:
+    """Factory for creating a dependency source object.
+
+    Args:
+        requirement (str): Package name/path/constraints in string form.
+        name (str, optional): Override package name.
+            Defaults to None.
+
+    Returns:
+        Appropriate Dependency Source
+
+    """
     req = next(requirements.parse(str(requirement)))
     if req.local_file:
         path = Path(req.path)

--- a/micropy/packages/package.py
+++ b/micropy/packages/package.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+
+from typing import List, Tuple
+
+from packaging.utils import canonicalize_name
+
+
+class Package:
+
+    def __init__(self, name: str, specs: List[Tuple[str, str]]):
+        self._name = name
+        self._specs = specs
+
+    @property
+    def name(self) -> str:
+        return canonicalize_name(self._name)
+
+    @property
+    def specs(self) -> List[Tuple[str, str]]:
+        return self._specs
+
+    @property
+    def pretty_specs(self) -> str:
+        if not self.specs:
+            return "*"
+        _specs = ["".join(i for i in s) for s in self.specs]
+        return "".join(_specs)
+
+    def __str__(self) -> str:
+        return self.name

--- a/micropy/packages/package.py
+++ b/micropy/packages/package.py
@@ -9,6 +9,13 @@ from packaging.utils import canonicalize_name
 class Package:
 
     def __init__(self, name: str, specs: List[Tuple[str, str]]):
+        """Generic Python Dependency.
+
+        Args:
+            name (str): Name of package
+            specs (List[Tuple[str, str]]): Package constraints.
+
+        """
         self._name = name
         self._specs = specs
 

--- a/micropy/packages/source.py
+++ b/micropy/packages/source.py
@@ -14,6 +14,12 @@ from .package import Package
 
 
 class DependencySource(AbstractContextManager):
+    """Base class for managing dependency sources.
+
+    Args:
+        package (Package): package the source points too.
+
+    """
     _ignore_stubs: List[str] = ['setup.py', '__version__', 'test_']
 
     def __init__(self, package: Package):
@@ -33,13 +39,14 @@ class DependencySource(AbstractContextManager):
             stack.pop_all()
 
     def get_root(self, path: Path) -> Optional[Path]:
-        """Determines package root if it has one
+        """Determines package root if it has one.
 
         Args:
             path (Path): Path to check
 
         Returns:
             bool: True if is package
+
         """
         init = next(path.rglob('__init__.py'), None)
         if init:
@@ -55,13 +62,14 @@ class DependencySource(AbstractContextManager):
         Returns:
             List[Tuple[Path, Path]]: List of tuples containing
                  a path to the original file and stub, respectively.
+
         """
         py_files = fileutils.iter_find_files(str(path), patterns='*.py', ignored=self._ignore_stubs)
         stubs = [utils.generate_stub(f) for f in py_files]
         return stubs
 
     def __enter__(self):
-        """Method to prepare source"""
+        """Method to prepare source."""
 
     def __exit__(self, *args):
         return super().__exit__(*args)

--- a/micropy/packages/source.py
+++ b/micropy/packages/source.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+
+from contextlib import AbstractContextManager, ExitStack, contextmanager
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from boltons import fileutils
+
+from micropy import utils
+from micropy.logger import Log, ServiceLog
+
+from .package import Package
+
+
+class DependencySource(AbstractContextManager):
+    _ignore_stubs: List[str] = ['setup.py', '__version__', 'test_']
+
+    def __init__(self, package: Package):
+        self._package = package
+        self.log: ServiceLog = Log.add_logger(repr(self))
+
+    @property
+    def package(self) -> Package:
+        return self._package
+
+    @contextmanager
+    def handle_cleanup(self):
+        with ExitStack() as stack:
+            stack.push(self)
+            yield
+            # no errors, continue on
+            stack.pop_all()
+
+    def get_root(self, path: Path) -> Optional[Path]:
+        """Determines package root if it has one
+
+        Args:
+            path (Path): Path to check
+
+        Returns:
+            bool: True if is package
+        """
+        init = next(path.rglob('__init__.py'), None)
+        if init:
+            return init.parent
+        return None
+
+    def generate_stubs(self, path: Path) -> List[Tuple[Path, Path]]:
+        """Generate Stub Files from a package.
+
+        Args:
+            path (Path): Path to package.
+
+        Returns:
+            List[Tuple[Path, Path]]: List of tuples containing
+                 a path to the original file and stub, respectively.
+        """
+        py_files = fileutils.iter_find_files(str(path), patterns='*.py', ignored=self._ignore_stubs)
+        stubs = [utils.generate_stub(f) for f in py_files]
+        return stubs
+
+    def __enter__(self):
+        """Method to prepare source"""
+
+    def __exit__(self, *args):
+        return super().__exit__(*args)
+
+    def __repr__(self):
+        return f"<{self.__class__} {self.package}>"

--- a/micropy/packages/source_package.py
+++ b/micropy/packages/source_package.py
@@ -12,6 +12,14 @@ from .source import DependencySource
 
 
 class PackageDependencySource(DependencySource):
+    """Dependency Source for pypi packages.
+
+    Args:
+        package (Package): Package source points too.
+        format_desc (Optional[Callable[..., Any]], optional): Callback to format progress bar description.
+            Defaults to None.
+
+    """
 
     def __init__(self, package: Package,
                  format_desc: Optional[Callable[..., Any]] = None):
@@ -28,12 +36,33 @@ class PackageDependencySource(DependencySource):
         return utils.get_url_filename(self.source_url)
 
     def fetch(self) -> bytes:
+        """Fetch package contents into memory.
+
+        Returns:
+            bytes: Package archive contents.
+
+        """
         self.log.debug(f"fetching package: {self.file_name}")
         desc = self.format_desc(self.file_name)
         content = utils.stream_download(self.source_url, desc=desc)
         return content
 
     def __enter__(self) -> Union[Path, List[Tuple[Path, Path]]]:
+        """Prepare Pypi package for installation.
+
+        Extracts the package into a temporary directory then
+        generates stubs for type hinting.
+        This helps with intellisense.
+
+        If the dependency is a module, a list
+        of tuples with the file and stub path, respectively,
+        will be returned. Otherwise, the path to the package
+        root will be returned.
+
+        Returns:
+            Union[Path, List[Tuple[Path, Path]]]: Root package path or list of files.
+
+        """
         with TemporaryDirectory() as tmp_dir:
             with self.handle_cleanup():
                 tmp = Path(tmp_dir)

--- a/micropy/packages/source_package.py
+++ b/micropy/packages/source_package.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Callable, List, Optional, Tuple, Union
+
+from micropy import utils
+
+from .package import Package
+from .source import DependencySource
+
+
+class PackageDependencySource(DependencySource):
+
+    def __init__(self, package: Package,
+                 format_desc: Optional[Callable[..., Any]] = None):
+        super().__init__(package)
+        self._meta: dict = utils.get_package_meta(str(self.package), self.package.pretty_specs)
+        self.format_desc = format_desc or (lambda n: n)
+
+    @property
+    def source_url(self) -> str:
+        return self._meta['url']
+
+    @property
+    def file_name(self) -> str:
+        return utils.get_url_filename(self.source_url)
+
+    def fetch(self) -> bytes:
+        self.log.debug(f"fetching package: {self.file_name}")
+        desc = self.format_desc(self.file_name)
+        content = utils.stream_download(self.source_url, desc=desc)
+        return content
+
+    def __enter__(self) -> Union[Path, List[Tuple[Path, Path]]]:
+        with TemporaryDirectory() as tmp_dir:
+            with self.handle_cleanup():
+                tmp = Path(tmp_dir)
+                path = utils.extract_tarbytes(self.fetch(), tmp)
+                stubs = self.generate_stubs(path)
+                pkg_root = self.get_root(path)
+            return pkg_root or stubs
+
+    def __exit__(self, *args):
+        return super().__exit__(*args)

--- a/micropy/packages/source_path.py
+++ b/micropy/packages/source_path.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Callable, List, Optional, Tuple, Union
+
+from micropy import utils
+
+from .package import Package
+from .source import DependencySource
+
+
+class LocalDependencySource(DependencySource):
+
+    def __init__(self, package: Package, path: Path):
+        super().__init__(package)
+        self._path = path
+
+    def __enter__(self) -> Path:
+        if self._path.is_file():
+            return self._path
+        _root = self.get_root(self._path)
+        if _root:
+            return _root
+        return self._path

--- a/micropy/packages/source_path.py
+++ b/micropy/packages/source_path.py
@@ -2,22 +2,32 @@
 
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Any, Callable, List, Optional, Tuple, Union
 
-from micropy import utils
 
 from .package import Package
 from .source import DependencySource
 
 
 class LocalDependencySource(DependencySource):
+    """Dependency Source that is available locally.
+
+    Args:
+        package (Package): Package source points too.
+        path (Path): Path to package.
+
+    """
 
     def __init__(self, package: Package, path: Path):
         super().__init__(package)
         self._path = path
 
     def __enter__(self) -> Path:
+        """Determines appropriate path.
+
+        Returns:
+            Path: Path to package root.
+
+        """
         if self._path.is_file():
             return self._path
         _root = self.get_root(self._path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,3 +180,22 @@ def mock_checks(mocker):
     type(m_run).stdout = mocker.PropertyMock(
         return_value="\n".join(mock_vscode_exts))
     return m_run
+
+
+@pytest.fixture
+def mock_pkg(mocker, tmp_path):
+    """return mock package"""
+    tmp_pkg = tmp_path / 'tmp_pkg'
+    tmp_pkg.mkdir()
+    (tmp_pkg / 'module.py').touch()
+    (tmp_pkg / 'file.py').touch()
+    mock_tarbytes = mocker.patch.object(
+        micropy.project.modules.packages.utils, 'extract_tarbytes')
+    mocker.patch.object(
+        micropy.project.modules.packages.utils, 'get_package_meta')
+    mocker.patch.object(
+        micropy.project.modules.packages.utils, 'get_url_filename')
+    mocker.patch.object(
+        micropy.project.modules.packages.utils, 'stream_download')
+    mock_tarbytes.return_value = tmp_pkg
+    return tmp_pkg

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+import pytest
+
+from micropy import packages, utils
+
+
+class TestPackages:
+
+    class MockSource:
+        def __init__(self, pkg, has_init):
+            self.pkg = pkg
+            self.has_init = has_init
+
+    @pytest.fixture(params=[True, False], ids=['package', 'module'])
+    def mock_source(self, request, mock_pkg):
+        if request.param:
+            # true packages vs file
+            (mock_pkg / '__init__.py').touch()
+        return self.MockSource(mock_pkg, request.param)
+
+    @pytest.fixture(params=[True, False, None], ids=['package', 'module', 'dir'])
+    def mock_source_path(self, request, tmp_path):
+        path = (tmp_path / 'file.py')
+        pkg = path
+        if request.param is True:
+            pkg = tmp_path
+            path = (tmp_path / '__init__.py')
+        if request.param is None:
+            pkg = tmp_path
+        path.touch()
+        return self.MockSource(pkg, request.param)
+
+    @pytest.mark.parametrize(
+        'package,expect',
+        [
+            ('picoweb', packages.PackageDependencySource),
+            ('-e /foobar/pkg', packages.LocalDependencySource)
+        ]
+    )
+    def test_factory(self, package, expect):
+        source = packages.create_dependency_source(package)
+        assert isinstance(source, expect)
+
+    @pytest.mark.parametrize(
+        'requirement,expect',
+        [
+            (['picoweb'], ['picoweb', '*']),
+            (['picoweb==^7.1'], ['picoweb', '==^7.1']),
+            (['BlynkLib==0.0.0'], ['blynklib', '==0.0.0']),
+            (['-e /foobar/somepkg', 'somepackage'], ['somepackage', '*']),
+            (['-e /foobar/somepkg'], ['somepkg', '*']),
+
+        ]
+    )
+    def test_package(self, mock_pkg, requirement, expect):
+        source = packages.create_dependency_source(*requirement)
+        pkg = source.package
+        assert pkg.name == expect[0]  # name
+        assert pkg.pretty_specs == expect[1]  # specs
+
+    def test_package_source(self, mock_source):
+        def format_desc(x): return f"desc{x}"
+        source = packages.create_dependency_source('blynklib', format_desc=format_desc)
+        with source as files:
+            if mock_source.has_init:
+                assert isinstance(files, Path)
+                assert mock_source.pkg.name == files.name
+            else:
+                assert isinstance(files, list)
+                file_one = files[0]
+                assert file_one[0].name == 'file.py'
+                assert file_one[1].name == 'file.pyi'
+
+    def test_package_path(self, mock_source_path):
+        source = packages.create_dependency_source(f'-e {mock_source_path.pkg}')
+        with source as files:
+            if mock_source_path.has_init:
+                # is proper package
+                assert files.is_dir()
+            if mock_source_path.has_init is False:
+                # is module
+                assert files.is_file()
+            if mock_source_path.has_init is None:
+                # is just a dir
+                assert files.is_dir()
+                assert files == source._path

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -70,9 +70,10 @@ class TestPackages:
                 assert mock_source.pkg.name == files.name
             else:
                 assert isinstance(files, list)
-                file_one = files[0]
-                assert file_one[0].name == 'file.py'
-                assert file_one[1].name == 'file.pyi'
+                file_names = [(p.name, s.name) for p, s in files]
+                file_names = list(sum(file_names, ()))
+                assert sorted(['file.py', 'file.pyi', 'module.py',
+                               'module.pyi']) == sorted(file_names)
 
     def test_package_path(self, mock_source_path):
         source = packages.create_dependency_source(f'-e {mock_source_path.pkg}')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -16,25 +16,6 @@ def mock_requests(mocker):
 
 
 @pytest.fixture
-def mock_pkg(mocker, tmp_path):
-    """return mock package"""
-    tmp_pkg = tmp_path / 'tmp_pkg'
-    tmp_pkg.mkdir()
-    (tmp_pkg / 'module.py').touch()
-    (tmp_pkg / 'file.py').touch()
-    mock_tarbytes = mocker.patch.object(
-        modules.packages.utils, 'extract_tarbytes')
-    mocker.patch.object(
-        modules.packages.utils, 'get_package_meta')
-    mocker.patch.object(
-        modules.packages.utils, 'get_url_filename')
-    mocker.patch.object(
-        modules.packages.utils, 'stream_download')
-    mock_tarbytes.return_value = tmp_pkg
-    return tmp_pkg
-
-
-@pytest.fixture
 def get_module():
     def _get_module(names, mp, **kwargs):
         _templates = list(modules.TemplatesModule.TEMPLATES.keys())
@@ -252,7 +233,7 @@ class TestPackagesModule:
         proj.create()
         return proj
 
-    def test_add_package(self, test_package):
+    def test_add_package(self, test_package, mock_cwd):
         proj = test_package
         proj.add_package('somepkg>=7')
         print(proj.config._config)


### PR DESCRIPTION
Added `micropy.packages` module which allows different types of dependencies (pypi, local, modules) to all interacted with using the same api. 

This will make implementing #71 and other types of sources (git, url, svn, etc) considerably easier.