### PR TITLE
feat: Load Project Modules by Priority Queue

### DIFF
--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -14,7 +14,6 @@ from micropy import main, utils
 from micropy.logger import Log
 from micropy.project import Project, modules
 
-
 pass_mpy = click.make_pass_decorator(main.MicroPy, ensure=True)
 
 
@@ -97,10 +96,10 @@ def init(mpy, path, name=None, template=None):
     stub_choices = prompt.checkbox(
         f"Which stubs would you like to use?", choices=stubs).ask()
     project = Project(path, name=name)
-    project.add(modules.StubsModule(mpy.stubs, stubs=stub_choices))
-    project.add(modules.PackagesModule('requirements.txt'))
-    project.add(modules.DevPackagesModule('dev-requirements.txt'))
-    project.add(modules.TemplatesModule(templates=template, run_checks=mpy.RUN_CHECKS))
+    project.add(modules.StubsModule, mpy.stubs, stubs=stub_choices)
+    project.add(modules.PackagesModule, 'requirements.txt')
+    project.add(modules.DevPackagesModule, 'dev-requirements.txt')
+    project.add(modules.TemplatesModule, templates=template, run_checks=mpy.RUN_CHECKS)
     proj_relative = project.create()
     mpy.log.title(f"Created $w[{project.name}] at $w[./{proj_relative}]")
 

--- a/micropy/main.py
+++ b/micropy/main.py
@@ -67,11 +67,10 @@ class MicroPy:
         """
         path = Path(path).absolute()
         proj = Project(path)
-        proj.add(modules.StubsModule(self.stubs))
-        proj.add(modules.PackagesModule('requirements.txt'))
-        proj.add(modules.DevPackagesModule(
-            'dev-requirements.txt'))
-        proj.add(modules.TemplatesModule(run_checks=self.RUN_CHECKS))
+        proj.add(modules.StubsModule, self.stubs)
+        proj.add(modules.PackagesModule, 'requirements.txt')
+        proj.add(modules.DevPackagesModule, 'dev-requirements.txt')
+        proj.add(modules.TemplatesModule, run_checks=self.RUN_CHECKS)
         if proj.exists:
             if verbose:
                 self.log.title(f"Loading Project")

--- a/micropy/project/modules/modules.py
+++ b/micropy/project/modules/modules.py
@@ -18,7 +18,7 @@ ProxyItem = List[Tuple[T, str]]
 
 class ProjectModule(metaclass=abc.ABCMeta):
     """Abstract Base Class for Project Modules."""
-
+    PRIORITY: int = 0
     _hooks: List['HookProxy'] = []
 
     @property

--- a/micropy/project/modules/modules.py
+++ b/micropy/project/modules/modules.py
@@ -21,6 +21,10 @@ class ProjectModule(metaclass=abc.ABCMeta):
     PRIORITY: int = 0
     _hooks: List['HookProxy'] = []
 
+    def __init__(self, parent: Optional['ProjectModule'] = None, log: Optional[ServiceLog] = None):
+        self._parent = parent
+        self.log = log
+
     @property
     def parent(self):
         """Component Parent."""

--- a/micropy/project/modules/modules.py
+++ b/micropy/project/modules/modules.py
@@ -57,7 +57,7 @@ class ProjectModule(metaclass=abc.ABCMeta):
     def update(self):
         """Method to update component."""
 
-    def add(self, component: Type['ProjectModule']) -> Any:
+    def add(self, component: Type['ProjectModule'], *args, **kwargs) -> Any:
         """Adds component.
 
         Args:

--- a/micropy/project/modules/packages.py
+++ b/micropy/project/modules/packages.py
@@ -23,6 +23,7 @@ class PackagesModule(ProjectModule):
             Defaults to None.
 
     """
+    PRIORITY: int = 8
 
     def __init__(self, path, packages=None, **kwargs):
         self._path = Path(path)
@@ -196,6 +197,7 @@ class PackagesModule(ProjectModule):
 
 class DevPackagesModule(PackagesModule):
     """Project Module for Dev Packages."""
+    PRIORITY: int = 7
 
     def __init__(self, path, **kwargs):
         super().__init__(path, **kwargs)

--- a/micropy/project/modules/packages.py
+++ b/micropy/project/modules/packages.py
@@ -26,12 +26,12 @@ class PackagesModule(ProjectModule):
     PRIORITY: int = 8
 
     def __init__(self, path, packages=None, **kwargs):
+        super().__init__(**kwargs)
         self._path = Path(path)
         self._loaded = False
         packages = packages or {}
         self.name = "packages"
         self.packages = {**packages}
-        self.log = kwargs.pop('logger', None)
 
     @property
     def path(self):

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -21,6 +21,7 @@ class StubsModule(ProjectModule):
         stubs (List[Type[Stub]], optional): Initial Stubs to use.
 
     """
+    PRIORITY: int = 9
 
     def __init__(self, stub_manager: StubManager,
                  stubs: Sequence[DeviceStub] = None):

--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -24,10 +24,10 @@ class StubsModule(ProjectModule):
     PRIORITY: int = 9
 
     def __init__(self, stub_manager: StubManager,
-                 stubs: Sequence[DeviceStub] = None):
+                 stubs: Sequence[DeviceStub] = None, **kwargs):
+        super().__init__(**kwargs)
         self.stub_manager: StubManager = stub_manager
         self._stubs: Sequence[DeviceStub] = stubs or []
-        self.log = None
 
     @property
     def context(self):

--- a/micropy/project/modules/templates.py
+++ b/micropy/project/modules/templates.py
@@ -3,7 +3,6 @@
 """Project Templates Module."""
 
 
-from micropy.logger import Log
 from micropy.project.modules import ProjectModule
 from micropy.project.template import TemplateProvider
 
@@ -25,19 +24,18 @@ class TemplatesModule(ProjectModule):
 
     def __init__(self, templates=None, run_checks=True, **kwargs):
         self.templates = templates or []
+        super().__init__(**kwargs)
         self.run_checks = run_checks
         self.enabled = {
             'vscode': False,
             'pylint': False
         }
-        self.log = Log.add_logger(
-            'Templater', show_title=False)
         if templates:
             for key in self.enabled:
                 if key in self.templates:
                     self.enabled[key] = True
         self.provider = TemplateProvider(
-            self.templates, run_checks=self.run_checks, log=self.log, **kwargs)
+            self.templates, **kwargs)
 
     @property
     def config(self):

--- a/micropy/project/modules/templates.py
+++ b/micropy/project/modules/templates.py
@@ -20,6 +20,7 @@ class TemplatesModule(ProjectModule):
             Defaults to True.
 
     """
+    PRIORITY: int = 0
     TEMPLATES = TemplateProvider.TEMPLATES
 
     def __init__(self, templates=None, run_checks=True, **kwargs):

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -142,9 +142,9 @@ class Project(ProjectModule):
             component (Any): Component to add.
 
         """
-        self.log.debug(f'adding module: {type(component).__name__}')
         child = component(*args, **kwargs, log=self.log, parent=self)
         self._children.append(child)
+        self.log.debug(f'adding module: {type(child).__name__}')
         if hasattr(child, 'context'):
             self.context.merge(child.context)
 

--- a/micropy/project/project.py
+++ b/micropy/project/project.py
@@ -4,7 +4,7 @@
 
 import json
 from pathlib import Path
-from typing import Any, Iterator, List, Optional, Sequence, Type
+from typing import Any, Iterator, List, Optional, Type
 
 from boltons.queueutils import PriorityQueue
 
@@ -121,10 +121,11 @@ class Project(ProjectModule):
         return value
 
     def iter_children_by_priority(self) -> Iterator[Type[ProjectModule]]:
-        """Iterate project modules by priority
+        """Iterate project modules by priority.
 
         Yields:
             the next child item
+
         """
         pq = PriorityQueue()
         for i in self._children:
@@ -142,7 +143,7 @@ class Project(ProjectModule):
 
         """
         self.log.debug(f'adding module: {type(component).__name__}')
-        child = component(*args, parent=self, log=self, **kwargs)
+        child = component(*args, **kwargs, log=self.log, parent=self)
         self._children.append(child)
         if hasattr(child, 'context'):
             self.context.merge(child.context)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,17 +58,26 @@ def mock_micropy(mock_micropy_path):
     return mp
 
 
-@pytest.fixture
-def mock_cwd(monkeypatch, tmp_path):
-    """Mock Path.cwd"""
-    def _mock_cwd():
-        return tmp_path
+# @pytest.fixture
+# def mock_cwd(monkeypatch, tmp_path):
+#     """Mock Path.cwd"""
+#     def _mock_cwd():
+#         return tmp_path
 
-    def _mock_resolve(self, **kwargs):
-        return tmp_path / self
-    monkeypatch.setattr(Path, 'cwd', _mock_cwd)
-    monkeypatch.setattr(Path, 'resolve', _mock_resolve)
-    return tmp_path
+#     def _mock_resolve(self, **kwargs):
+#         return tmp_path / self
+#     monkeypatch.setattr(Path, 'cwd', _mock_cwd)
+#     monkeypatch.setattr(Path, 'resolve', _mock_resolve)
+#     yield tmp_path
+#     shutil.rmtree(tmp_path, ignore_errors=True)
+
+@pytest.fixture
+def mock_cwd(request, tmp_path, mocker):
+    print(request)
+    import pathlib
+    mocker.patch('pathlib.Path.cwd')
+    pathlib.Path.cwd.return_value = (tmp_path)
+    yield (tmp_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,19 +58,6 @@ def mock_micropy(mock_micropy_path):
     return mp
 
 
-# @pytest.fixture
-# def mock_cwd(monkeypatch, tmp_path):
-#     """Mock Path.cwd"""
-#     def _mock_cwd():
-#         return tmp_path
-
-#     def _mock_resolve(self, **kwargs):
-#         return tmp_path / self
-#     monkeypatch.setattr(Path, 'cwd', _mock_cwd)
-#     monkeypatch.setattr(Path, 'resolve', _mock_resolve)
-#     yield tmp_path
-#     shutil.rmtree(tmp_path, ignore_errors=True)
-
 @pytest.fixture
 def mock_cwd(request, tmp_path, mocker):
     print(request)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,7 +102,6 @@ def test_cli_init(mocker, mock_mpy, shared_datadir, mock_prompt, runner, cliargs
     mock_project.assert_called_once_with(exp_path, **exp_project)
     # mock_add = mock_project.return_value.add
     # Assert Templates
-    exp_template = expargs.pop('template', {})
     expect_calls = [
         mocker.call(mock_modules.StubsModule, mock_mpy.stubs, stubs=['stub']),
         mocker.call(mock_modules.PackagesModule, "requirements.txt"),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,3 +95,15 @@ def test_resolve_project(mocker, mock_micropy):
     mock_proj.exists = True
     assert mock_micropy.resolve_project('.')
 
+
+# def test_create_project(mock_cwd, mock_micropy, get_stub_paths, tmp_path):
+#     """high-level test"""
+#     from micropy.project import Project, modules
+#     # Setup Micropy
+#     mp = mock_micropy
+#     stub_paths = get_stub_paths(count=2, valid=True)
+#     for i in stub_paths:
+#         mp.stubs.add(i)
+#     proj_stub = list(mp.stubs)[0]
+#     # Create Project
+#     proj = Project()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -94,3 +94,4 @@ def test_resolve_project(mocker, mock_micropy):
     assert not mock_micropy.resolve_project('.').exists
     mock_proj.exists = True
     assert mock_micropy.resolve_project('.')
+

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import shutil
-from functools import partial
 
 import pytest
 
@@ -207,15 +206,6 @@ class TestProject:
 
 class TestStubsModule:
 
-    # @pytest.fixture
-    # def stub_module(self, get_module, micropy_stubs, mocker, tmp_path):
-    #     mp = micropy_stubs()
-    #     mocker.patch.object(modules.StubsModule, 'parent')
-    #     stub_mod = next(get_module('stubs', mp))
-    #     stub_mod = modules.StubsModule(mp.stubs, **stub_mod[1], log=mocker.Mock())
-    #     stub_mod.parent.data_path = tmp_path
-    #     return stub_mod, mp
-
     @pytest.fixture()
     def stub_module(self, mocker, tmp_path, micropy_stubs):
         mp = micropy_stubs()
@@ -225,16 +215,6 @@ class TestStubsModule:
         stub_mod = modules.StubsModule(
             mp.stubs, stubs=[stub_item], parent=parent_mock, log=mocker.Mock())
         return stub_mod, mp
-
-    # def test_resolve_stubs(self, stub_module, mocker):
-    #     stub_module, mp = stub_module
-    #     assert len(stub_module.stubs) == 1
-    #     stub_module.stub_manager.resolve_subresource = mocker.MagicMock()
-    #     stub_module.stub_manager.resolve_subresource.side_effect = [OSError]
-    #     assert stub_module._resolve_subresource([]) == stub_module._stubs
-    #     stub_module._parent = mocker.MagicMock()
-    #     with pytest.raises(SystemExit):
-    #         stub_module._resolve_subresource([])
 
     def test_load(self, tmp_project, stub_module, get_stub_paths):
         custom_stub = next(get_stub_paths())


### PR DESCRIPTION
Removes the restrictions on how/when/where one can add a project module to a project by adding a `PRIORITY` attribute to each module (defaults to lowest). 

The `Project` container will now iterate over its child modules through a queue determined by the child priority, ensuring modules that need to be loaded first are ready.

When adding a project module, do not instantiate it anymore. Just pass the module class plus any args and kwargs. This makes module initialization much easier to deal with.