### PR TITLE
fix: VSCode Settings failed to populate on reload

### DIFF
--- a/micropy/project/modules/stubs.py
+++ b/micropy/project/modules/stubs.py
@@ -128,7 +128,7 @@ class StubsModule(ProjectModule):
         stubs = list(self._load_stub_data(stub_data=stub_data))
         stubs.extend(self.stubs)
         self.stubs = self._resolve_subresource(stubs)
-        return self.stubs
+        return self.update()
 
     def create(self):
         """Create stub project files."""
@@ -139,8 +139,9 @@ class StubsModule(ProjectModule):
 
     def update(self):
         """Update current project stubs."""
-        self.stubs = self.load()
-        self.parent.config.set('stubs', {s.name: s.stub_version for s in self._stubs})
+        self.parent.context.set('stubs', self.stubs)
+        self.parent.context.set('paths', self.context.get('paths'))
+        self.parent.config.set('stubs', {s.name: s.stub_version for s in self.stubs})
         return self.stubs
 
     @ProjectModule.hook()

--- a/poetry.lock
+++ b/poetry.lock
@@ -734,6 +734,18 @@ idna = ">=2.5,<2.9"
 urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
 
 [[package]]
+category = "dev"
+description = "Mock out responses from the requests package"
+name = "requests-mock"
+optional = false
+python-versions = "*"
+version = "1.7.0"
+
+[package.dependencies]
+requests = ">=2.3,<3"
+six = "*"
+
+[[package]]
 category = "main"
 description = "Parses Pip requirement files"
 name = "requirements-parser"
@@ -1019,7 +1031,7 @@ version = "0.6.0"
 more-itertools = "*"
 
 [metadata]
-content-hash = "428ee378e9f9566705892383060a6350e3aabcf3bd6e702c261174dcf698bf26"
+content-hash = "3baed4c0091aa6fbb8737f2c45d83cdda62fcd8157f0bb6cf53ac4c271deb07f"
 python-versions = "^3.6"
 
 [metadata.hashes]
@@ -1095,6 +1107,7 @@ pyyaml = ["0e7f69397d53155e55d10ff68fdfb2cf630a35e6daf65cf0bdeaf04f127c09dc", "2
 questionary = ["7d4f98c9e5a1c0cd7e45a2c13959d5df9de3f55cb208d7b0265e4dd53dede584", "87ffc9dab940ec962c54fe2eec3a4eecb10f7cfa91994fc94c839476f4099154"]
 recommonmark = ["29cd4faeb6c5268c633634f2d69aef9431e0f4d347f90659fd0aab20e541efeb", "2ec4207a574289355d5b6ae4ae4abb29043346ca12cdd5f07d374dc5987d2852"]
 requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
+requests-mock = ["510df890afe08d36eca5bb16b4aa6308a6f85e3159ad3013bac8b9de7bd5a010", "88d3402dd8b3c69a9e4f9d3a73ad11b15920c6efd36bc27bf1f701cf4a8e4646"]
 requirements-parser = ["5963ee895c2d05ae9f58d3fc641082fb38021618979d6a152b6b1398bd7d4ed4", "76650b4a9d98fc65edf008a7920c076bb2a76c08eaae230ce4cfc6f51ea6a773"]
 restructuredtext-lint = ["97b3da356d5b3a8514d8f1f9098febd8b41463bed6a1d9f126cf0a048b6fd908"]
 rope = ["6b728fdc3e98a83446c27a91fc5d56808a004f8beab7a31ab1d7224cecc7d969", "c5c5a6a87f7b1a2095fb311135e2a3d1f194f5ecb96900fdd0a9100881f48aaf", "f0dcf719b63200d492b85535ebe5ea9b29e0d0b8aebeb87fe03fc1a65924fdaf"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ mypy = "^0.750.0"
 doc8 = "^0.8.0"
 docformatter = "^1.3"
 codacy-coverage = "^1.3"
+requests-mock = "^1.7"
 
 [tool.dephell.main]
 from = {format = "poetry", path="pyproject.toml"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,3 +196,18 @@ def mock_pkg(mocker, tmp_path):
     mock_tarbytes.return_value = tmp_pkg
     mock_meta.return_value = {'url': 'http://realurl.com'}
     return tmp_pkg
+
+
+# Pytest Incremental Marker
+def pytest_runtest_makereport(item, call):
+    if "incremental" in item.keywords:
+        if call.excinfo is not None:
+            parent = item.parent
+            parent._previousfailed = item
+
+
+def pytest_runtest_setup(item):
+    if "incremental" in item.keywords:
+        previousfailed = getattr(item.parent, "_previousfailed", None)
+        if previousfailed is not None:
+            pytest.xfail("previous test failed ({})".format(previousfailed.name))

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import json
+from pathlib import Path
 
 import pytest
 import requests
@@ -52,9 +53,9 @@ class TestCreateProject:
     }
 
     expect_vsc_data = [
-        ".micropy/esp32_test_stub/frozen",
-        ".micropy/esp32_test_stub/stubs",
-        ".micropy/NewProject"
+        str(Path(".micropy/esp32_test_stub/frozen")),
+        str(Path(".micropy/esp32_test_stub/stubs")),
+        str(Path(".micropy/NewProject"))
     ]
 
     def check_mp_data(self, path):

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+import json
+
+import pytest
+import requests
+
+from micropy import main, project
+
+
+@pytest.fixture
+def mock_requests(mocker, requests_mock, test_archive):
+    mock_source = {
+        "name": "Micropy Stubs",
+        "location": "https://codeload.github.com/BradenM/micropy-stubs",
+        "source": "https://raw.githubusercontent.com/bradenm/micropy-stubs/source.json",
+        "path": "legacy.tar.gz/pkg/",
+        "packages": [
+            {
+                "name": "micropython",
+                "type": "firmware",
+                "sha256sum": "7ff2cce0237268cd52164b77b6c2df6be6249a67ee285edc122960af869b8ed2"
+            },
+        ]
+    }
+    requests_mock.get(
+        "https://raw.githubusercontent.com/BradenM/micropy-stubs/master/source.json",
+        json=mock_source)
+    requests_mock.get(
+        "https://codeload.github.com/BradenM/micropy-stubs/legacy.tar.gz/pkg/micropython",
+        content=test_archive)
+
+
+@pytest.mark.usefixtures("mock_cwd", "mock_pkg", "mock_requests")
+@pytest.mark.incremental
+class TestCreateProject:
+    mp = None
+
+    expect_mp_data = {
+        'name': 'NewProject',
+        'stubs': {
+            'esp32-1.11.0': '1.2.0'
+        },
+        'packages': {},
+        'dev-packages': {
+            'micropy-cli': '*'
+        },
+        'config': {
+            'vscode': True,
+            'pylint': True
+        }
+    }
+
+    expect_vsc_data = [
+        ".micropy/esp32_test_stub/frozen",
+        ".micropy/esp32_test_stub/stubs",
+        ".micropy/NewProject"
+    ]
+
+    def check_mp_data(self, path):
+        micropy_file = path
+        assert micropy_file.exists()
+        mp_data = json.loads(micropy_file.read_text())
+        assert mp_data.items() == self.expect_mp_data.items()
+
+    def check_vscode(self, path):
+        vsc_path = path
+        assert vsc_path.exists()
+        with vsc_path.open() as f:
+            lines = [l.strip() for l in f.readlines() if l]
+            valid = [l for l in lines if "//" not in l[:2]]
+        vsc_data = json.loads("\n".join(valid))
+        assert vsc_data['python.analysis.typeshedPaths'] == self.expect_vsc_data
+
+    def test_setup_stubs(self, mock_micropy, get_stub_paths, shared_datadir):
+        mpy = mock_micropy
+        stub_path = (shared_datadir / 'esp32_test_stub')
+        mpy.stubs.add(stub_path)
+
+    def test_create_project(self, mock_micropy, tmp_path, shared_datadir):
+        mpy = mock_micropy
+        stub_path = (shared_datadir / 'esp32_test_stub')
+        mpy.stubs.add(stub_path)
+        proj_path = (tmp_path / 'NewProject')
+        self.proj = project.Project(proj_path)
+        proj_stub = list(mpy.stubs)[0]
+        self.proj.add(project.modules.StubsModule, mpy.stubs, stubs=[proj_stub])
+        self.proj.add(project.modules.PackagesModule, 'requirements.txt')
+        self.proj.add(project.modules.DevPackagesModule, 'dev-requirements.txt')
+        self.proj.add(project.modules.TemplatesModule, ('vscode', 'pylint'))
+        self.proj.create()
+        self.check_mp_data(self.proj.info_path)
+        self.check_vscode(self.proj.path / '.vscode' / 'settings.json')
+        # Reload micropy project and check again
+        self.proj = mpy.resolve_project(self.proj.path)
+        self.check_mp_data(self.proj.info_path)
+        self.check_vscode(self.proj.path / '.vscode' / 'settings.json')


### PR DESCRIPTION
After creating a project, the vscode stub path settings would be deleted upon executing `micropy` a second time. This fix ensures the context for the vscode template is
set and adds a new high level test module to ensure this doesnt happen
again.

This issue is not present on the latest stable release (v3.1.1)