### PR TITLE
fix: Handle Package Install Errors

### DIFF
--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -157,12 +157,14 @@ def install(mpy, packages, dev=False, path=None):
         sys.exit(0)
     if not packages:
         mpy.log.title("Installing all Requirements")
-        reqs = project.add_from_file(dev=dev)
-        if not reqs:
-            mpy.log.error("No requirements.txt file found!")
-            sys.exit(1)
-        mpy.log.success("\nRequirements Installed!")
-        sys.exit(0)
+        try:
+            project.add_from_file(dev=dev)
+        except Exception as e:
+            mpy.error(f"Failed to load requirements!", exception=e)
+            raise click.Abort()
+        else:
+            mpy.log.success("\nRequirements Installed!")
+            sys.exit(0)
     mpy.log.title("Installing Packages")
     for pkg in packages:
         try:

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -167,9 +167,9 @@ def install(mpy, packages, dev=False, path=None):
     for pkg in packages:
         try:
             project.add_package(pkg, dev=dev)
-        except exc.RequirementNotFound as e:
+        except exc.RequirementException as e:
             pkg_name = str(e.package)
-            mpy.log.error((f"Could not find {pkg_name}!"
+            mpy.log.error((f"Failed to install {pkg_name}!"
                            " Is it available on PyPi?"), exception=e)
             raise click.Abort()
 

--- a/micropy/cli.py
+++ b/micropy/cli.py
@@ -165,7 +165,13 @@ def install(mpy, packages, dev=False, path=None):
         sys.exit(0)
     mpy.log.title("Installing Packages")
     for pkg in packages:
-        project.add_package(pkg, dev=dev)
+        try:
+            project.add_package(pkg, dev=dev)
+        except exc.RequirementNotFound as e:
+            pkg_name = str(e.package)
+            mpy.log.error((f"Could not find {pkg_name}!"
+                           " Is it available on PyPi?"), exception=e)
+            raise click.Abort()
 
 
 @stubs.command(short_help="Add Stubs from package or path")

--- a/micropy/exceptions.py
+++ b/micropy/exceptions.py
@@ -3,7 +3,11 @@
 """Micropy Exceptions."""
 
 
-class StubError(Exception):
+class MicropyException(Exception):
+    """Generic MicroPy Exception"""
+
+
+class StubError(MicropyException):
     """Exception for any errors raised by stubs."""
 
     def __init__(self, message=None, stub=None):
@@ -33,3 +37,15 @@ class StubNotFound(StubError):
         stub_name = stub_name or "Unknown"
         msg = f"{stub_name} is not available!"
         return super().__init__(msg)
+
+
+class RequirementException(MicropyException):
+    """A Requirement Exception Occurred"""
+
+    def __init__(self, *args, **kwargs):
+        self.package = kwargs.pop('package', None)
+        super().__init__(*args, **kwargs)
+
+
+class RequirementNotFound(RequirementException):
+    """A requirement could not be found."""

--- a/micropy/exceptions.py
+++ b/micropy/exceptions.py
@@ -4,7 +4,7 @@
 
 
 class MicropyException(Exception):
-    """Generic MicroPy Exception"""
+    """Generic MicroPy Exception."""
 
 
 class StubError(MicropyException):
@@ -40,7 +40,7 @@ class StubNotFound(StubError):
 
 
 class RequirementException(MicropyException):
-    """A Requirement Exception Occurred"""
+    """A Requirement Exception Occurred."""
 
     def __init__(self, *args, **kwargs):
         self.package = kwargs.pop('package', None)

--- a/micropy/packages/source_package.py
+++ b/micropy/packages/source_package.py
@@ -33,7 +33,7 @@ class PackageDependencySource(DependencySource):
             raise RequirementNotFound(
                 f"{self.source_url} is not a valid url!", package=self.package)
         self._meta: dict = utils.get_package_meta(
-            str(self.package),
+            self.package.name,
             self.source_url,
             self.package.pretty_specs
         )
@@ -41,7 +41,7 @@ class PackageDependencySource(DependencySource):
 
     @property
     def source_url(self) -> str:
-        _url = self.repo.format(name=str(self.package))
+        _url = self.repo.format(name=self.package.name)
         return _url
 
     @property

--- a/micropy/packages/source_package.py
+++ b/micropy/packages/source_package.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from tempfile import mkdtemp
 from typing import Any, Callable, List, Optional, Tuple, Union
 
-from requests import RequestException
 
 from micropy import utils
 from micropy.exceptions import RequirementNotFound
@@ -31,9 +30,9 @@ class PackageDependencySource(DependencySource):
         super().__init__(package)
         try:
             utils.ensure_valid_url(self.repo_url)
-        except RequestException:
+        except Exception:
             raise RequirementNotFound(
-                f"{self.source_url} is not a valid url!", package=self.package)
+                f"{self.repo_url} is not a valid url!", package=self.package)
         else:
             self._meta: dict = utils.get_package_meta(
                 str(self.package),
@@ -43,12 +42,12 @@ class PackageDependencySource(DependencySource):
 
     @property
     def repo_url(self) -> str:
-        _url = self.repo.format(name=str(self.package))
+        _url = self.repo.format(name=self.package.name)
         return _url
 
     @property
     def source_url(self) -> str:
-        return self._meta['url']
+        return self._meta.get('url', None)
 
     @property
     def file_name(self) -> str:

--- a/micropy/project/modules/packages.py
+++ b/micropy/project/modules/packages.py
@@ -149,15 +149,10 @@ class PackagesModule(ProjectModule):
         self.config.add(self.name + '/' + pkg.name, pkg.pretty_specs)
         try:
             self.load()
-        except ValueError as e:
-            self.log.error(f"Failed to find package $[{pkg.name}]!")
-            self.log.error("Is it available on PyPi?", exception=e)
+        except Exception:
+            self.log.debug(f"failed to install: {pkg.name}")
             self.config.pop(self.name + '/' + pkg.name)
-        except Exception as e:
-            self.log.error(
-                f"An error occured during the installation of $[{pkg.name}]!",
-                exception=e)
-            self.config.pop(self.name + '/' + pkg.name)
+            raise
         else:
             if pkg.editable:
                 self.context.extend('local_paths', [pkg.path], unique=True)

--- a/micropy/utils/helpers.py
+++ b/micropy/utils/helpers.py
@@ -259,14 +259,12 @@ def iter_requirements(path):
             yield req
 
 
-def get_package_meta(name, url, spec=None):
+def get_package_meta(name, url):
     """Retrieve package metadata from PyPi.
 
     Args:
-        name (str): Name of package.
+        name (str): Name of package with specs.
         url (str): Url to package.
-        spec (str, optional): Optional version spec.
-            Defaults to None. If none, returns latest.
 
     Returns:
         dict: Dictionary of Metadata
@@ -279,12 +277,11 @@ def get_package_meta(name, url, spec=None):
                 yield t
     resp = requests.get(url)
     data = resp.json()
-    pkg_name = f"{name}{spec}" if spec and spec != "*" else name
-    pkg = next(requirements.parse(pkg_name))
+    pkg = next(requirements.parse(name))
     releases = data['releases']
     # Latest version
     spec_data = list(releases.items())[-1][1]
-    if pkg.specs and spec != '*':
+    if pkg.specs:
         spec_comp, spec_v = pkg.specs[0]
         spec_v = version.parse(spec_v)
         rel_versions = [version.parse(k) for k in releases.keys()]

--- a/micropy/utils/helpers.py
+++ b/micropy/utils/helpers.py
@@ -71,12 +71,8 @@ def ensure_valid_url(url):
     """
     if not is_url(url):
         raise reqexc.InvalidURL(f"{url} is not a valid url!")
-    try:
-        resp = requests.head(url)
-    except reqexc.ConnectionError as e:
-        raise e
-    else:
-        resp.raise_for_status()
+    resp = requests.head(url, allow_redirects=True)
+    resp.raise_for_status()
     return url
 
 

--- a/micropy/utils/helpers.py
+++ b/micropy/utils/helpers.py
@@ -259,10 +259,11 @@ def iter_requirements(path):
             yield req
 
 
-def get_package_meta(name, url=, spec=None):
+def get_package_meta(name, url, spec=None):
     """Retrieve package metadata from PyPi.
 
     Args:
+        name (str): Name of package.
         url (str): Url to package.
         spec (str, optional): Optional version spec.
             Defaults to None. If none, returns latest.

--- a/micropy/utils/helpers.py
+++ b/micropy/utils/helpers.py
@@ -259,11 +259,11 @@ def iter_requirements(path):
             yield req
 
 
-def get_package_meta(name, spec=None):
+def get_package_meta(name, url=, spec=None):
     """Retrieve package metadata from PyPi.
 
     Args:
-        name (str): Name of Package
+        url (str): Url to package.
         spec (str, optional): Optional version spec.
             Defaults to None. If none, returns latest.
 
@@ -276,7 +276,6 @@ def get_package_meta(name, spec=None):
             state = eval(f"in_val {operator} t")
             if state:
                 yield t
-    url = f"https://pypi.org/pypi/{name}/json"
     resp = requests.get(url)
     data = resp.json()
     pkg_name = f"{name}{spec}" if spec and spec != "*" else name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,7 @@ def mock_pkg(mocker, tmp_path):
     (tmp_pkg / 'module.py').touch()
     (tmp_pkg / 'file.py').touch()
     mocker.patch.object(
-        packages.source_package.utils, 'is_downloadable', return_value=True)
+        packages.source_package.utils, 'ensure_valid_url')
     mock_tarbytes = mocker.patch.object(
         packages.source_package.utils, 'extract_tarbytes')
     mock_meta = mocker.patch.object(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,6 +194,8 @@ def mock_pkg(mocker, tmp_path):
     tmp_pkg.mkdir()
     (tmp_pkg / 'module.py').touch()
     (tmp_pkg / 'file.py').touch()
+    mocker.patch.object(
+        packages.source_package.utils, 'is_downloadable', return_value=True)
     mock_tarbytes = mocker.patch.object(
         packages.source_package.utils, 'extract_tarbytes')
     mock_meta = mocker.patch.object(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,8 +172,10 @@ class TestInstall:
     def test_from_requirements(self, runner, mock_proj):
         result = runner.invoke(cli.install, "")
         assert result.exit_code == 0
-        mock_proj.add_from_file.return_value = None
+        mock_proj.add_from_file.side_effect = [FileNotFoundError]
         result = runner.invoke(cli.install, "")
+        assert result.exit_code == 1
+        assert "Aborted!" in result.output
 
     def test_no_project_found(self, runner):
         result = runner.invoke(cli.install, ["package"])
@@ -184,3 +186,9 @@ class TestInstall:
         result = runner.invoke(cli.install, ["badpackage"])
         assert result.exit_code == 1
         assert "Aborted!" in result.output
+
+    def test_from_path(self, runner, mock_proj, tmp_path):
+        tmp_package = tmp_path / 'mycustompackage'
+        tmp_package.mkdir()
+        result = runner.invoke(cli.install, ['--path', str(tmp_package)])
+        assert result.exit_code == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -157,7 +157,7 @@ def test_get_package_meta(mocker, requests_mock):
     assert result == {
         "url": "return-me.tar.gz"
     }
-    result = utils.get_package_meta("foobar", "https://pypi.org/pypi/foobar/json", spec="==0.0.0")
+    result = utils.get_package_meta("foobar==0.0.0", "https://pypi.org/pypi/foobar/json")
     assert result == {
         "url": "early-version.tar.gz"
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,9 +133,8 @@ def test_generate_stub(shared_datadir, tmp_path, mocker):
     assert print_mock.call_count >= 1
 
 
-def test_get_package_meta(mocker):
+def test_get_package_meta(mocker, requests_mock):
     """should get package meta"""
-    mock_req = mocker.patch.object(utils.helpers, 'requests')
     mock_data = {
         "releases": {
             "0.0.0": [
@@ -153,13 +152,12 @@ def test_get_package_meta(mocker):
             ],
         }
     }
-    mock_req.get.return_value.json.return_value = mock_data
-    result = utils.get_package_meta("foobar")
+    requests_mock.get("https://pypi.org/pypi/foobar/json", json=mock_data)
+    result = utils.get_package_meta("foobar", "https://pypi.org/pypi/foobar/json")
     assert result == {
         "url": "return-me.tar.gz"
     }
-    mock_req.get.assert_called_once_with("https://pypi.org/pypi/foobar/json")
-    result = utils.get_package_meta("foobar", spec="==0.0.0")
+    result = utils.get_package_meta("foobar", "https://pypi.org/pypi/foobar/json", spec="==0.0.0")
     assert result == {
         "url": "early-version.tar.gz"
     }


### PR DESCRIPTION
Fixes:

* `utils.ensure_valid_url` by forcing it to follow `301` or any other redirect status codes. (Fixes #85)
* Adding packages from file path via `PackagesModule.add_from_file` (Fixes #86)
* Attempts to parse path as url (#86)

Changes:

* Added `MicropyException` base exception class
* Added `RequirementException` sub-exception class
* Added `RequirementNotFound` exception
* `utils.get_package_meta` now takes a url rather than a package name
* Any package related exceptions are now handled/reported in the cli module, where it should be. (#86 and #85)