### PR TITLE
Add Pylance support

### DIFF
--- a/micropy/project/template/.vscode/settings.json
+++ b/micropy/project/template/.vscode/settings.json
@@ -6,6 +6,7 @@
     "python.autoComplete.extraPaths": {{ paths }},
     "python.autoComplete.typeshedPaths":  {{ paths }},
     "python.analysis.typeshedPaths":  {{ paths }},
+    "python.analysis.extraPaths":  {{ paths }},
 
     "python.linting.pylintEnabled": true
 }

--- a/tests/data/project_test/.vscode/settings.json
+++ b/tests/data/project_test/.vscode/settings.json
@@ -26,6 +26,14 @@
         "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/stubs",
         "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/stubs"
     ],
+    "python.analysis.extraPaths": [
+        "${workspaceRoot}/.micropy/micropython/frozen",
+        "${workspaceRoot}/.micropy/micropython/frozen",
+        "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/frozen",
+        "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/frozen",
+        "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/stubs",
+        "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/stubs"
+    ],
 
     "python.linting.pylintEnabled": true
 }


### PR DESCRIPTION
I just added Pylance autocompletion support. 
Pylance uses `python.analysis.extraPaths` instead of `python.autoComplete.extraPaths`.

Fix #152