### PR TITLE
Cross Compilation of `createstubs.py` + File Integrity Checks

### DIFF
--- a/micropy/exceptions.py
+++ b/micropy/exceptions.py
@@ -1,4 +1,5 @@
 """Micropy Exceptions."""
+from __future__ import annotations
 
 
 class MicropyException(Exception):
@@ -61,3 +62,16 @@ class PyDeviceConnectionError(PyDeviceError):
 
     def __init__(self, location: str):
         super().__init__(self._default_message.format(location=location))
+
+
+class PyDeviceFileIntegrityError(PyDeviceError):
+    _default_message = (
+        "Failed to verify integrity: {device_path} (device={device_sum}, recv={digest})"
+    )
+
+    def __init__(self, device_path: str, device_sum: str, digest: str):
+        super().__init__(
+            self._default_message.format(
+                device_path=device_path, device_sum=device_sum, digest=digest
+            )
+        )

--- a/micropy/pyd/abc.py
+++ b/micropy/pyd/abc.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import abc
+from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Any, AnyStr, NewType, Protocol
+from typing import Any, AnyStr, Generic, NewType, Protocol, TypeVar
 
 HostPath = NewType("HostPath", str)
 DevicePath = NewType("DevicePath", str)
@@ -136,8 +137,11 @@ class MetaPyDeviceBackend(abc.ABC):
         ...
 
 
-class MetaPyDevice(abc.ABC):
-    pydevice: MetaPyDeviceBackend
+AnyBackend = TypeVar("AnyBackend", bound=MetaPyDeviceBackend)
+
+
+class MetaPyDevice(abc.ABC, Generic[AnyBackend]):
+    pydevice: AnyBackend
     stream_consumer: StreamConsumer | None
     message_consumer: MessageConsumer | None
 
@@ -154,9 +158,17 @@ class MetaPyDevice(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def copy_from(self, source_path: DevicePath, target_path: HostPath) -> None:
+    def copy_from(
+        self, source_path: DevicePath, target_path: HostPath, *, verify_integrity: bool = True
+    ) -> None:
         ...
 
     @abc.abstractmethod
-    def run_script(self, content: AnyStr, target_path: DevicePath | None = None):
+    def remove(self, target_path: DevicePath) -> None:
+        ...
+
+    @abc.abstractmethod
+    def run_script(
+        self, content: AnyStr | StringIO | BytesIO, target_path: DevicePath | None = None
+    ):
         ...

--- a/micropy/pyd/abc.py
+++ b/micropy/pyd/abc.py
@@ -112,6 +112,10 @@ class MetaPyDeviceBackend(abc.ABC):
         ...
 
     @abc.abstractmethod
+    def remove(self, path: DevicePath) -> None:
+        ...
+
+    @abc.abstractmethod
     def copy_dir(
         self,
         source_path: DevicePath,

--- a/micropy/pyd/backend_rshell.py
+++ b/micropy/pyd/backend_rshell.py
@@ -230,3 +230,6 @@ class RShellPyDeviceBackend(MetaPyDeviceBackend):
                 raise Exception(str(e)) from e
             out = out_bytes.decode("utf-8")
             return out
+
+    def remove(self, path: DevicePath) -> None:
+        self._rsh.rm(str(path))

--- a/micropy/pyd/backend_upydevice.py
+++ b/micropy/pyd/backend_upydevice.py
@@ -331,3 +331,6 @@ class UPyDeviceBackend(MetaPyDeviceBackend):
         self.write_file(contents, DevicePath(_target_path), consumer=consumer)
         self.eval(f"import {Path(_target_path).stem}", consumer=consumer)
         self.uos.remove(str(_target_path))
+
+    def remove(self, path: DevicePath) -> None:
+        self.uos.remove(str(path))

--- a/micropy/pyd/backend_upydevice.py
+++ b/micropy/pyd/backend_upydevice.py
@@ -311,19 +311,17 @@ class UPyDeviceBackend(MetaPyDeviceBackend):
         value = buffer.getvalue().decode()
         return value
 
-    def eval(self, command: str, *, consumer: MessageConsumer | None = None) -> str | None:
-        if consumer:
-            return self._pydevice.cmd(
-                command, follow=True, pipe=lambda m, *args, **kws: consumer.on_message(m)
-            )
-        return self._pydevice.cmd(command)
+    def eval(self, command: str, *, consumer: MessageConsumer = NoOpConsumer) -> str | None:
+        return self._pydevice.cmd(
+            command, follow=True, pipe=lambda m, *args, **kws: consumer.on_message(m)
+        )
 
     def eval_script(
         self,
         contents: AnyStr,
         target_path: DevicePath | None = None,
         *,
-        consumer: PyDeviceConsumer | None = None,
+        consumer: PyDeviceConsumer = NoOpConsumer,
     ):
         _target_path = (
             self.resolve_path(target_path) if target_path else f"{self._rand_device_path()}.py"

--- a/micropy/pyd/backend_upydevice.py
+++ b/micropy/pyd/backend_upydevice.py
@@ -277,7 +277,7 @@ class UPyDeviceBackend(MetaPyDeviceBackend):
         consumer.on_start(
             name=f"Reading {Path(target_path).name} (xsize: {chunk_size})", size=int(content_size)
         )
-        hasher = hashlib.sha256(usedforsecurity=False)
+        hasher = hashlib.sha256()
         while pos < content_size:
             try:
                 cmd = read_chunk_cmd.format(path=str(target_path), pos=pos, chunk_size=chunk_size)

--- a/micropy/pyd/consumers.py
+++ b/micropy/pyd/consumers.py
@@ -72,3 +72,12 @@ class StreamHandlers(NamedTuple):
 
 class MessageHandlers(NamedTuple):
     on_message: MessageHandler
+
+
+def _no_op(*args, **kwargs):
+    return None
+
+
+NoOpStreamConsumer = StreamHandlers(on_start=_no_op, on_update=_no_op, on_end=_no_op)
+NoOpMessageConsumer = MessageHandlers(on_message=_no_op)
+NoOpConsumer = ConsumerDelegate(NoOpMessageConsumer, NoOpMessageConsumer)

--- a/micropy/pyd/pydevice.py
+++ b/micropy/pyd/pydevice.py
@@ -68,6 +68,9 @@ class PyDevice(MetaPyDevice[AnyBackend], Generic[AnyBackend]):
             raise RuntimeError("Copying dirs to device is not yet supported!")
         return self.pydevice.push_file(source_path, target_path, consumer=self.consumer, **kwargs)
 
+    def remove(self, target_path: DevicePath) -> None:
+        return self.pydevice.remove(target_path)
+
     def connect(self):
         return self.pydevice.connect()
 

--- a/micropy/utils/stub.py
+++ b/micropy/utils/stub.py
@@ -88,7 +88,8 @@ def prepare_create_stubs(
     modules_set: Optional[stub_board.ListChangeSet] = None,
     problem_set: Optional[stub_board.ListChangeSet] = None,
     exclude_set: Optional[stub_board.ListChangeSet] = None,
-) -> io.StringIO:
+    compile: bool = False,
+) -> io.StringIO | io.BytesIO:
     if stub_board is None:
         raise ImportError("micropython-stubber requires a python version of >= 3.8")
     variant = variant or stub_board.CreateStubsVariant.BASE
@@ -103,7 +104,9 @@ def prepare_create_stubs(
     minify.minify(result_io, minified_io, keep_report=True, diff=False)
     minified_io.seek(0)
     # TODO: compile w/ mpy-cross
-    # compiled_io = io.BytesIO()
-    # minify.cross_compile(minified_io, compiled_io)
-    # compiled_io.seek(0)
+    if compile:
+        compiled_io = io.BytesIO()
+        minify.cross_compile(minified_io, compiled_io)
+        compiled_io.seek(0)
+        return compiled_io
     return minified_io

--- a/tests/app/test_stubs.py
+++ b/tests/app/test_stubs.py
@@ -27,7 +27,7 @@ def test_create_changeset(input, expected):
 
 @pytest.fixture()
 def pydevice_mock(mocker: MockerFixture):
-    def mock_copy_from(dev_path, tmp_dir):
+    def mock_copy_from(dev_path, tmp_dir, **kwargs):
         stub_dir = Path(tmp_dir) / "stubs"
         stub_dir.mkdir()
 

--- a/tests/test_pyd.py
+++ b/tests/test_pyd.py
@@ -366,6 +366,26 @@ class TestPyDevice:
                 verify_integrity=mocker.ANY,
             )
 
+    def test_copy_from__integrity(self, mock_backend, path_type, mocker):
+        pyd = PyDevice(MOCK_PORT, backend=mock_backend)
+        ptype, p = path_type
+        if ptype == "dir":
+            pyd.copy_from(p, "/host/path", verify_integrity=True, exclude_integrity={"abc.py"})
+        else:
+            pyd.copy_from(p, "/host/path", verify_integrity=True)
+        if ptype == "dir":
+            mock_backend.return_value.copy_dir.assert_called_once_with(
+                p,
+                "/host/path",
+                consumer=mocker.ANY,
+                verify_integrity=True,
+                exclude_integrity={"abc.py"},
+            )
+        else:
+            mock_backend.return_value.pull_file.assert_called_once_with(
+                p, "/host/path", consumer=mocker.ANY, verify_integrity=True
+            )
+
     def test_copy_to(self, mock_backend, path_type, mocker):
         pyd = PyDevice(MOCK_PORT, backend=mock_backend)
         ptype, p = path_type

--- a/tests/test_pyd.py
+++ b/tests/test_pyd.py
@@ -238,6 +238,23 @@ class TestPyDeviceBackend:
         mock_upy_retry.assert_not_called()
         assert m.device.cmd.call_count == 6
 
+    def test_read_file__with_integrity_fail(self, mock_upy_retry, pymock, mocker: MockFixture):
+        m = pymock
+        if m.is_rsh:
+            # upy only
+            return
+        # content size
+        m.mock_uos.return_value.stat.side_effect = ["ENOENT", [0, 0, 0, 0, 0, 0, 8]]
+        # chunk size will default to 8/4
+        chunks = [b"Hi", b" t", b"he", b"re"]
+        m.device.cmd.side_effect = [8, *chunks, "notrightsha"]
+        reset_mock = mocker.MagicMock()
+        pyd = self.pyd_cls().establish(MOCK_PORT)
+        pyd.reset = reset_mock
+        pyd.read_file("/some/path", verify_integrity=True)
+        assert reset_mock.call_count == 4
+        assert m.device.cmd.call_count == 6
+
     def test_read_file__bad_chunk(self, mock_upy_retry, pymock, mocker: MockFixture):
         m = pymock
         if m.is_rsh:

--- a/tests/test_pyd.py
+++ b/tests/test_pyd.py
@@ -10,7 +10,7 @@ from unittest.mock import ANY, MagicMock
 import pytest
 from micropy.exceptions import PyDeviceError
 from micropy.pyd import backend_rshell, backend_upydevice, consumers
-from micropy.pyd.abc import MetaPyDeviceBackend, PyDeviceConsumer
+from micropy.pyd.abc import DevicePath, MetaPyDeviceBackend, PyDeviceConsumer
 from micropy.pyd.pydevice import PyDevice
 from pytest_mock import MockFixture
 
@@ -431,6 +431,11 @@ class TestPyDevice:
             mock_backend.return_value.push_file.assert_called_once_with(
                 "/host/path/f.txt", p, consumer=mocker.ANY
             )
+
+    def test_remove(self, mock_backend):
+        pyd = PyDevice(MOCK_PORT, backend=mock_backend)
+        pyd.remove(DevicePath("/some/path"))
+        mock_backend.return_value.remove.assert_called_once_with("/some/path")
 
 
 class TestConsumers:

--- a/tests/test_pyd.py
+++ b/tests/test_pyd.py
@@ -233,10 +233,10 @@ class TestPyDeviceBackend:
             chunks_hash.update(chunk)
         m.device.cmd.side_effect = [8, *chunks, chunks_hash.hexdigest()]
         pyd = self.pyd_cls().establish(MOCK_PORT)
-        res = pyd.read_file("/some/path", verify_integrity=False)
+        res = pyd.read_file("/some/path", verify_integrity=True)
         assert res == "Hi there"
         mock_upy_retry.assert_not_called()
-        assert m.device.cmd.call_count == 5
+        assert m.device.cmd.call_count == 6
 
     def test_read_file__bad_chunk(self, mock_upy_retry, pymock, mocker: MockFixture):
         m = pymock

--- a/tests/test_pyd.py
+++ b/tests/test_pyd.py
@@ -238,6 +238,24 @@ class TestPyDeviceBackend:
         mock_upy_retry.assert_not_called()
         assert m.device.cmd.call_count == 5
 
+    def test_read_file__bad_chunk(self, mock_upy_retry, pymock, mocker: MockFixture):
+        m = pymock
+        if m.is_rsh:
+            # upy only
+            return
+        # content size
+        m.mock_uos.return_value.stat.side_effect = ["ENOENT", [0, 0, 0, 0, 0, 0, 8]]
+        # chunk size will default to 8/4
+        chunks = [b"Hi", b"", b" t", b"he", b"re"]
+        m.device.cmd.side_effect = [8, *chunks]
+        m.mock.Device.return_value.reset = mocker.MagicMock(return_value=None)
+        pyd = self.pyd_cls().establish(MOCK_PORT)
+        res = pyd.read_file("/some/path", verify_integrity=False)
+        assert res == "Hi there"
+        mock_upy_retry.assert_not_called()
+        assert m.device.cmd.call_count == 6
+        assert m.mock.Device.return_value.reset.call_count == 1
+
     def test_pull_file(self, pymock, tmp_path, mock_upy_retry):
         m = pymock
         pyd = self.pyd_cls().establish(MOCK_PORT)

--- a/tests/test_pyd.py
+++ b/tests/test_pyd.py
@@ -228,7 +228,7 @@ class TestPyDeviceBackend:
         m.mock_uos.return_value.stat.side_effect = ["ENOENT", [0, 0, 0, 0, 0, 0, 8]]
         # chunk size will default to 8/4
         chunks = [b"Hi", b" t", b"he", b"re"]
-        chunks_hash = hashlib.sha256(usedforsecurity=False)
+        chunks_hash = hashlib.sha256()
         for chunk in chunks:
             chunks_hash.update(chunk)
         m.device.cmd.side_effect = [8, *chunks, chunks_hash.hexdigest()]


### PR DESCRIPTION
- feat(utils): support compiling createstubs with mpy-cross
- feat(exc): `PyDeviceFileIntegrityError` exception.
- feat(pyd): `NoOpConsumer` implementation.
- fix(pyd): support pushing binary files to pydevice in upydevice backend.
- feat(pyd): file integrity check support in upydevice backend.
- feat(pydevice): file integrity support, simple run in pydevice.
- feat(pyd): implement `remove` across backends.
- feat(app): expose compile, module-defaults flags, integrity in stubs create command.
