### PR TITLE
Resolve pylance/pylint/vscode configuration issues causing import errors and typings issues.

### DIFF
--- a/micropy/project/template.py
+++ b/micropy/project/template.py
@@ -192,6 +192,7 @@ class CodeTemplate(Template):
         ctx = {
             "stubs": self.stubs or [],
             "paths": stub_paths,
+            "typeshed_paths": json.dumps([str(s) for s in [*paths, "typings"]]),
             "language_server": self.language_server,
         }
         return ctx

--- a/micropy/project/template/.pylintrc
+++ b/micropy/project/template/.pylintrc
@@ -1,11 +1,11 @@
-[MASTER]
+[MAIN]
 # Loaded Stubs: {% for stub in stubs %} {{ stub }} {% endfor %}
 init-hook='import sys;sys.path[1:1]=["src/lib",{% for path in paths %}"{{ path|replace("\\", "/") }}", {% endfor %} ]'
 
 [MESSAGES CONTROL]
 # Only show warnings with the listed confidence levels. Leave empty to show
 # all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
-confidence=
+confidence=INFERENCE
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this

--- a/micropy/project/template/.vscode/settings.json
+++ b/micropy/project/template/.vscode/settings.json
@@ -4,6 +4,10 @@
     "python.languageServer": "Pylance",
     "python.analysis.autoSearchPath": true,
     "python.autoComplete.extraPaths": {{ paths }},
+    "python.analysis.diagnosticSeverityOverrides": { "reportMissingModuleSource": "none" },
+    "python.analysis.typeCheckingMode": "basic",
+    "python.autoComplete.typeshedPaths":  {{ typeshed_paths }},
+    "python.analysis.typeshedPaths":  {{ typeshed_paths }},
     {% endif %}
     {% if language_server == 'mpls' %}
     "python.jediEnabled": false,

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -462,6 +462,13 @@ class Stub:
         if copy_to is not None:
             self.copy_to(copy_to)
 
+    def find_root(self, path: Path) -> Path:
+        """Attempt to find appropriate stub root."""
+        pyi_files = path.rglob("*.pyi")
+        if pyi_path := next(pyi_files, None):
+            return pyi_path.parent
+        return path
+
     def copy_to(self, dest, name=None):
         """Copy stub to a directory."""
         if not name:
@@ -519,9 +526,11 @@ class DeviceStub(Stub):
         super().__init__(path, copy_to, **kwargs)
 
         stubs_path = self.path / "stubs"
-        self.stubs = stubs_path if stubs_path.exists() else self.path
+        self.stubs = self.find_root(stubs_path if stubs_path.exists() else self.path)
+
         frozen_path = self.path / "frozen"
-        self.frozen = frozen_path if frozen_path.exists() else self.path
+        self.frozen = self.find_root(frozen_path if frozen_path.exists() else self.path)
+
         stubber = self.info.get("stubber")
         self.stub_version = stubber.get("version")
 

--- a/micropy/stubs/stubs.py
+++ b/micropy/stubs/stubs.py
@@ -386,13 +386,13 @@ class StubManager:
         # oh lawd, look away!!
         dev_name = min(name_parts, key=lambda s: len(s))
         name_parts.remove(dev_name)
-        name_parts.pop()
+        firm_name = name_parts.pop()
         firm = {
             "ver": meta.version or "",
             "port": dev_name,
             "arch": "",
             "sysname": dev_name,
-            "name": "",
+            "name": firm_name,
             "mpy": 0,
             "version": meta.version or "",
             "machine": "",


### PR DESCRIPTION
- fix(stubs): do not drop firmware name when parsing from dist metadata.
- fix(stubs): always ensure correct pyi stub root paths.
- fix(template): update pylint config to use `MAIN` and `INFERENCE` confidence level.
- fix(template): resolve pylance type-checking / import errors.


Closes #474 

Ref #471 
