### PR TITLE
docs: Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,7 +355,7 @@
 -   **pkg:** upgrade too and pin jinja2 @ 3.0.3
 -   **project:** report exception on install failure to stdout
 -   **stubber:** replace pyminifer with python-minifer
--   **utils:** capture attribue err that occurs on py310 win32 rshell import
+-   **utils:** capture attribute err that occurs on py310 win32 rshell import
 -   **utils:** utilize mp-stubbers new logic for generating stubs
 
 ### Features
@@ -820,7 +820,7 @@ No longer compatible with <=ms-python.python[@2019](https://github.com/2019).8.3
 
 ### Bug Fixes
 
--   Fails First Time Setup Failed to init on first run if the stubs folder didnt exist
+-   Fails First Time Setup Failed to init on first run if the stubs folder didn't exist
 -   Removed old command
 -   Fix Project Init
 -   Added rshell to setup.py

--- a/micropy/config/config.py
+++ b/micropy/config/config.py
@@ -73,7 +73,7 @@ class Config:
         """Parses key.
 
         Splits it into a path and 'final key'
-        object. Each key is seperates by a: "/"
+        object. Each key is separates by a: "/"
 
         Example:
             >>> self.parse_key('item/subitem/value')

--- a/micropy/project/template.py
+++ b/micropy/project/template.py
@@ -17,7 +17,7 @@ class Template:
         template (jinja2.Template): Jinja2 Template Instance
 
     Raises:
-        NotImplementedError: Method must be overriden by subclass
+        NotImplementedError: Method must be overridden by subclass
 
     """
 

--- a/micropy/pyd/backend_rshell.py
+++ b/micropy/pyd/backend_rshell.py
@@ -174,7 +174,7 @@ class RShellPyDeviceBackend(MetaPyDeviceBackend):
         Args:
             source_path: path to directory
             target_path: destination to copy to
-            rsync (dict, optional): additonal args to pass to rsync call.
+            rsync (dict, optional): additional args to pass to rsync call.
                 Defaults to {}
 
         """

--- a/micropy/utils/helpers.py
+++ b/micropy/utils/helpers.py
@@ -78,7 +78,7 @@ def ensure_valid_url(url):
     Raises:
         InvalidURL: URL is not a valid url
         ConnectionError: Failed to connect to url
-        HTTPError: Reponse was not 200 <OK>
+        HTTPError: Response was not 200 <OK>
 
     Returns:
         str: valid url

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,7 @@ class TestConfig:
         cfg_file.write_text(json.dumps(self.default))
         conf = config.Config(cfg_file, default={})
         assert conf.config == self.default
-        # default should be overriden
+        # default should be overridden
         conf = config.Config(cfg_file, default={"one": 1})
         assert utils.dict_equal(conf.raw(), self.default)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,7 @@ def test_setup(mock_micropy_path):
     mp = main.MicroPy(options=config)
     assert expect_mp_dir.exists()
     assert expect_stubs_dir.exists()
-    # Test after inital setup
+    # Test after initial setup
     mp_ = main.MicroPy(options=config)
     assert len(mp_.stubs) == len(mp.stubs)
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -142,7 +142,7 @@ def test_project_queue(tmp_path, mock_cwd, mocker):
     # should be called in order of priority (9 being highest)
     mock_parent.assert_has_calls(
         [
-            # adding them doesnt matter
+            # adding them doesn't matter
             mocker.call.m1(log=mocker.ANY, parent=mocker.ANY),
             mocker.call.m2(log=mocker.ANY, parent=mocker.ANY),
             mocker.call.m3(log=mocker.ANY, parent=mocker.ANY),
@@ -248,7 +248,7 @@ class TestPackagesModule:
         proj, mp = next(test_project("reqs"))
         proj.create()
         proj.add_package("somepkg==7")
-        # Shouldnt allow duplicate pkgs
+        # Shouldn't allow duplicate pkgs
         res = proj.add_package("somepkg")
         assert res is None
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -162,7 +162,7 @@ def test_loads_from_resource(datadir, mock_fware):
 
 
 def test_name_property(shared_datadir):
-    """should raise error if name is not overriden"""
+    """should raise error if name is not overridden"""
     test_stub = shared_datadir / "esp8266_test_stub"
 
     class ErrorStub(stubs.stubs.Stub):


### PR DESCRIPTION
Found via `codespell -S poetry.lock -L ure`