### PR TITLE
Remove deprecated VS Code linting settings

### DIFF
--- a/micropy/project/template/.vscode/settings.json
+++ b/micropy/project/template/.vscode/settings.json
@@ -7,14 +7,11 @@
     "python.analysis.diagnosticSeverityOverrides": { "reportMissingModuleSource": "none" },
     "python.analysis.typeCheckingMode": "basic",
     "python.autoComplete.typeshedPaths":  {{ typeshed_paths }},
-    "python.analysis.typeshedPaths":  {{ typeshed_paths }},
+    "python.analysis.typeshedPaths":  {{ typeshed_paths }}
     {% endif %}
     {% if language_server == 'mpls' %}
     "python.jediEnabled": false,
     "python.autoComplete.typeshedPaths":  {{ paths }},
-    "python.analysis.typeshedPaths":  {{ paths }},
+    "python.analysis.typeshedPaths":  {{ paths }}
     {% endif %}
-
-    "python.linting.enabled": true,
-    "python.linting.pylintEnabled": true
 }

--- a/tests/data/project_test/.vscode/settings.json
+++ b/tests/data/project_test/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-    "python.linting.enabled": true,
-
     // Loaded Stubs:  esp32-micropython-1.11.0  esp8266-micropython-1.11.0
     "python.autoComplete.extraPaths": [
         "${workspaceRoot}/.micropy/micropython/frozen",
@@ -33,7 +31,5 @@
         "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/frozen",
         "${workspaceRoot}/.micropy/esp32-micropython-1.11.0/stubs",
         "${workspaceRoot}/.micropy/esp8266-micropython-1.11.0/stubs"
-    ],
-
-    "python.linting.pylintEnabled": true
+    ]
 }


### PR DESCRIPTION
## Summary
- remove deprecated python.linting.* entries from the generated VS Code settings template
- update the project test fixture to match the generated settings file
- keep the rendered settings JSON valid after removing the trailing linting entries

Closes #586

## Validation
- Not run locally.
- Remote: pre-commit.ci passed.
- Remote: GitHub Actions are blocked before project tests or analysis. CodeQL fails during setup with Poetry reporting 'pyproject.toml changed significantly since poetry.lock was last generated'. The Test MicropyCli jobs that have started fail in the 'Setup environment.' step before 'Run Tests'; the macOS-12 jobs remain queued.