### PR TITLE
Avoid false junction detection from drive-letter case

### DIFF
--- a/micropy/utils/helpers.py
+++ b/micropy/utils/helpers.py
@@ -380,8 +380,7 @@ def is_dir_link(path):
         return True
     if platform == "win32":
         # Test for Directory Junction
-        resolved = str(path.resolve())
-        if not str(path.absolute()) == resolved:
+        if path.absolute() != path.resolve():
             return True
     return False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import io
 import sys
+from pathlib import PureWindowsPath
 
 import pytest
 import requests
@@ -226,7 +227,7 @@ def test_is_dir_link(mocker, tmp_path):
     mock_sys = mocker.patch.object(utils.helpers, "sys")
     mock_platform = type(mock_sys).platform = mocker.PropertyMock()
     mock_path = mocker.patch.object(utils.helpers, "Path").return_value
-    mock_path.is_symlink.side_effect = [True, False, False, False]
+    mock_path.is_symlink.side_effect = [True, False, False, False, False]
     # Test Symlink (POSIX)
     mock_platform.return_value = "linux"
     assert utils.is_dir_link(link_path)
@@ -241,6 +242,9 @@ def test_is_dir_link(mocker, tmp_path):
     mock_path.absolute.return_value = link_path
     assert utils.is_dir_link(link_path)
     mock_path.absolute.return_value = targ_path
+    assert not utils.is_dir_link(link_path)
+    mock_path.absolute.return_value = PureWindowsPath("c:/micropy/link")
+    mock_path.resolve.return_value = PureWindowsPath("C:/micropy/link")
     assert not utils.is_dir_link(link_path)
 
 


### PR DESCRIPTION
Fixes #208.

## Summary
- compare Windows link paths as `Path` objects instead of stringifying them
- add a regression for drive-letter-only case differences when checking junctions

## Validation
- `git diff --check`
- `git show --check --stat --oneline HEAD`
- Not run locally.
- Remote: pre-commit.ci passed.
- Remote: GitHub Actions are blocked before project tests or analysis. CodeQL and the Test MicropyCli jobs fail during setup with Poetry reporting `pyproject.toml changed significantly since poetry.lock was last generated`; macOS-12 Test MicropyCli jobs were later cancelled after remaining queued.