### PR TITLE
Avoid Git executable check during package import

### DIFF
--- a/micropy/packages/source_package.py
+++ b/micropy/packages/source_package.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from tempfile import mkdtemp
 from typing import Any, Callable, List, Optional, Tuple, Union
 
-from git import Repo
 from micropy import utils
 from micropy.exceptions import RequirementNotFound
 
@@ -96,7 +95,7 @@ class VCSDependencySource(DependencySource):
         self.log.debug(
             f"VCS package!, {self.package.revision}@{self.package.vcs}@{self.package.full_name}"
         )
-        self._repo: Optional[Repo] = None
+        self._repo: Optional[Any] = None
         try:
             utils.ensure_valid_url(self.repo_url)
         except Exception as e:
@@ -128,6 +127,8 @@ class VCSDependencySource(DependencySource):
             Path to clone repository.
 
         """
+        from git import Repo
+
         self.log.debug(f"fetching vcs package: ${self.file_name} @ ${self.repo_url}")
         self.format_desc(self.file_name)
         self._repo = Repo.clone_from(self.repo_url, str(dest_path))

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,3 +1,5 @@
+import importlib
+import sys
 from pathlib import Path
 
 import pytest
@@ -5,6 +7,29 @@ from boltons.namedutils import namedlist
 from micropy import packages
 
 EXPPKG = namedlist("ExpectPackage", ["name", "specs", "full_name"])
+
+
+def test_source_package_import_does_not_require_git_executable(monkeypatch):
+    source_module_name = "micropy.packages.source_package"
+    original_module = sys.modules.pop(source_module_name, None)
+    packages_module = sys.modules.get("micropy.packages")
+    original_attr = getattr(packages_module, "source_package", None)
+
+    class BrokenGitModule:
+        def __getattr__(self, name):
+            raise ImportError("Bad git executable.")
+
+    monkeypatch.setitem(sys.modules, "git", BrokenGitModule())
+    try:
+        source_package = importlib.import_module(source_module_name)
+        assert source_package.PackageDependencySource
+        assert source_package.VCSDependencySource
+    finally:
+        sys.modules.pop(source_module_name, None)
+        if original_module is not None:
+            sys.modules[source_module_name] = original_module
+        if packages_module is not None:
+            setattr(packages_module, "source_package", original_attr)
 
 
 class TestPackages:

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -29,7 +29,7 @@ def test_source_package_import_does_not_require_git_executable(monkeypatch):
         if original_module is not None:
             sys.modules[source_module_name] = original_module
         if packages_module is not None:
-            setattr(packages_module, "source_package", original_attr)
+            packages_module.source_package = original_attr
 
 
 class TestPackages:


### PR DESCRIPTION
Fixes #619.

## Summary
- delay importing GitPython's `Repo` until a VCS dependency is actually fetched
- keep PyPI/local dependency handling importable when Git is not installed or not on PATH
- add a regression that imports `micropy.packages.source_package` with a broken `git` module

## Validation
- `git diff --check`
- Not run locally: project tests, lint, build, install, import runtime, or Git/GitPython execution.
- Remote: pre-commit.ci passed.
- Remote: GitHub Actions are blocked before project tests or analysis. CodeQL and the Ubuntu/Windows Test MicropyCli jobs fail during setup with Poetry reporting `pyproject.toml changed significantly since poetry.lock was last generated`; macOS-12 Test MicropyCli jobs are still queued.